### PR TITLE
[Feature] /member/signup 회원가입 기능 구현 (시큐리티 적용 전)

### DIFF
--- a/src/main/java/com/example/fastboard/FastBoardApplication.java
+++ b/src/main/java/com/example/fastboard/FastBoardApplication.java
@@ -2,8 +2,10 @@ package com.example.fastboard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class FastBoardApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/fastboard/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/fastboard/domain/member/controller/MemberController.java
@@ -1,0 +1,26 @@
+package com.example.fastboard.domain.member.controller;
+
+import com.example.fastboard.domain.member.dto.request.MemberCreateRequest;
+import com.example.fastboard.domain.member.service.MemberService;
+import com.example.fastboard.global.common.ResponseDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ResponseDTO<Void>> create(@Valid @RequestBody MemberCreateRequest request) {
+        memberService.signup(request);
+        return ResponseEntity.ok(ResponseDTO.ok());
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/member/dto/request/MemberCreateRequest.java
+++ b/src/main/java/com/example/fastboard/domain/member/dto/request/MemberCreateRequest.java
@@ -1,0 +1,33 @@
+package com.example.fastboard.domain.member.dto.request;
+
+import com.example.fastboard.domain.member.entity.Member;
+import com.example.fastboard.domain.member.entity.Role;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record MemberCreateRequest(
+        @NotBlank(message = "이름은 필수 입력 값입니다.")
+        String name,
+        @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+        String nickname,
+        @NotBlank(message = "전화번호는 필수 입력 값입니다.")
+        String phoneNumber,
+        @Email
+        String email,
+        @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+        @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+        String password
+) {
+
+    public Member toEntity(String encryptedPassword) {
+        return Member.builder()
+                .name(name)
+                .nickname(nickname)
+                .phoneNumber(phoneNumber)
+                .email(email)
+                .encryptedPassword(encryptedPassword)
+                .role(Role.USER)
+                .build();
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/member/entity/Member.java
+++ b/src/main/java/com/example/fastboard/domain/member/entity/Member.java
@@ -2,9 +2,12 @@ package com.example.fastboard.domain.member.entity;
 
 import com.example.fastboard.global.common.BaseEntitySoftDelete;
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor
 public class Member extends BaseEntitySoftDelete {
     @Id
@@ -22,4 +25,14 @@ public class Member extends BaseEntitySoftDelete {
     private String encryptedPassword;
     @Column(nullable = false)
     private Role role;
+
+    @Builder
+    private Member(String name, String nickname, String phoneNumber, String email, String encryptedPassword, Role role) {
+        this.name = name;
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+        this.email = email;
+        this.encryptedPassword = encryptedPassword;
+        this.role = role;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/member/exception/MemberAlreadyException.java
+++ b/src/main/java/com/example/fastboard/domain/member/exception/MemberAlreadyException.java
@@ -1,0 +1,11 @@
+package com.example.fastboard.domain.member.exception;
+
+import com.example.fastboard.global.exception.ApplicationException;
+import com.example.fastboard.global.exception.ErrorCode;
+
+public class MemberAlreadyException extends ApplicationException {
+
+    public MemberAlreadyException(ErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/member/exception/MemberDeletedException.java
+++ b/src/main/java/com/example/fastboard/domain/member/exception/MemberDeletedException.java
@@ -1,0 +1,10 @@
+package com.example.fastboard.domain.member.exception;
+
+import com.example.fastboard.global.exception.ApplicationException;
+import com.example.fastboard.global.exception.ErrorCode;
+
+public class MemberDeletedException extends ApplicationException {
+    public MemberDeletedException() {
+        super(ErrorCode.MEMBER_DELETED_EXCEPTION);
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/fastboard/domain/member/repository/MemberRepository.java
@@ -1,0 +1,17 @@
+package com.example.fastboard.domain.member.repository;
+
+import com.example.fastboard.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
+
+    Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByNickname(String nickname);
+
+    Optional<Member> findByPhoneNumber(String phoneNumber);
+}

--- a/src/main/java/com/example/fastboard/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/example/fastboard/domain/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,6 @@
+package com.example.fastboard.domain.member.repository;
+
+public interface MemberRepositoryCustom {
+    //구현 메소드정의
+    void testMethod1();
+}

--- a/src/main/java/com/example/fastboard/domain/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/example/fastboard/domain/member/repository/MemberRepositoryCustomImpl.java
@@ -1,0 +1,9 @@
+package com.example.fastboard.domain.member.repository;
+
+public class MemberRepositoryCustomImpl implements MemberRepositoryCustom{
+
+    @Override
+    public void testMethod1() {
+        System.out.println("testMethod1");
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/fastboard/domain/member/service/MemberService.java
@@ -1,0 +1,50 @@
+package com.example.fastboard.domain.member.service;
+
+import com.example.fastboard.domain.member.dto.request.MemberCreateRequest;
+import com.example.fastboard.domain.member.entity.Member;
+import com.example.fastboard.domain.member.exception.MemberAlreadyException;
+import com.example.fastboard.domain.member.exception.MemberDeletedException;
+import com.example.fastboard.domain.member.repository.MemberRepository;
+import com.example.fastboard.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public void signup(MemberCreateRequest request) {
+        if (isAvailableEmail(request.email())) {
+            memberRepository.findByNickname(request.nickname())
+                    .ifPresent(mem -> {
+                        throw new MemberAlreadyException(ErrorCode.MEMBER_NICKNAME_ALREADY_EXIST_EXCEPTION);
+                    });
+            memberRepository.findByPhoneNumber(request.phoneNumber())
+                    .ifPresent(mem -> {
+                        throw new MemberAlreadyException(ErrorCode.MEMBER_PHONE_NUMBER_ALREADY_EXIST_EXCEPTION);
+                    });
+
+            String encryptedPassword = request.password(); // 패스워드 암호화 기능 추가 필요
+            Member newMember = request.toEntity(encryptedPassword);
+            memberRepository.save(newMember);
+        }
+    }
+
+    private Boolean isAvailableEmail(String email) {
+        Optional<Member> member = memberRepository.findByEmail(email);
+        if (member.isPresent()) {
+            if (member.get().isDelete()) {
+                throw new MemberDeletedException();
+            } else {
+                throw new MemberAlreadyException(ErrorCode.MEMBER_ALREADY_REGISTERED_EXCEPTION);
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/example/fastboard/global/common/ResponseDTO.java
+++ b/src/main/java/com/example/fastboard/global/common/ResponseDTO.java
@@ -1,0 +1,57 @@
+package com.example.fastboard.global.common;
+
+import com.example.fastboard.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ResponseDTO<T> {
+    private final int status;
+    private final T data;
+    private final String message;
+
+
+    public static ResponseDTO<Void> ok() {
+        return ResponseDTO.<Void>builder()
+                .status(HttpStatus.OK.value())
+                .data(null)
+                .message(null)
+                .build();
+    }
+
+    public static <T> ResponseDTO<T> okWithData(T data) {
+        return ResponseDTO.<T>builder()
+                .status(HttpStatus.OK.value())
+                .data(data)
+                .message(null)
+                .build();
+    }
+
+    public static <T> ResponseDTO<T> okWithMessageAndData(String message, T data){
+        return ResponseDTO.<T>builder()
+                .status(HttpStatus.OK.value())
+                .data(data)
+                .message(message)
+                .build();
+    }
+
+    public static ResponseDTO<Void> error(ErrorCode errorCode) {
+        return ResponseDTO.<Void>builder()
+                .status(errorCode.getHttpStatus().value())
+                .message(errorCode.getMessage())
+                .data(null)
+                .build();
+    }
+
+    public static ResponseDTO<Void> errorWithMessage(HttpStatus httpStatus, String errorMessage) {
+        return ResponseDTO.<Void>builder()
+                .status(httpStatus.value())
+                .message(errorMessage)
+                .data(null)
+                .build();
+    }
+}

--- a/src/main/java/com/example/fastboard/global/exception/ApplicationException.java
+++ b/src/main/java/com/example/fastboard/global/exception/ApplicationException.java
@@ -16,6 +16,9 @@ public class ApplicationException extends RuntimeException{
 
     @Override
     public String getMessage() {
+        if(errorCode.getMessage()!=null){
+            return errorCode.getMessage();
+        }
         return super.getMessage();
     }
 }

--- a/src/main/java/com/example/fastboard/global/exception/ApplicationException.java
+++ b/src/main/java/com/example/fastboard/global/exception/ApplicationException.java
@@ -1,0 +1,21 @@
+package com.example.fastboard.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApplicationException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    protected ApplicationException(ErrorCode errorCode,String message){
+        super(message);
+        this.errorCode=errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return super.getMessage();
+    }
+}

--- a/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.example.fastboard.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    //500 error
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
@@ -8,6 +8,13 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    //MEMBER
+    MEMBER_DELETED_EXCEPTION(HttpStatus.NOT_FOUND, "삭제된 회원입니다."),
+    MEMBER_ALREADY_REGISTERED_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 존재하는 회원 이메일 입니다."),
+    MEMBER_NICKNAME_ALREADY_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST,"이미 존재하는 닉네임 입니다."),
+    MEMBER_PHONE_NUMBER_ALREADY_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST,"이미 존재하는 전화번호 입니다."),
+
+
     //500 error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
 

--- a/src/main/java/com/example/fastboard/global/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/example/fastboard/global/exception/GlobalExceptionAdvice.java
@@ -1,17 +1,63 @@
 package com.example.fastboard.global.exception;
 
 import com.example.fastboard.global.common.ResponseDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionAdvice {
 
     @ExceptionHandler(ApplicationException.class)
-    public ResponseEntity<ResponseDTO<Void>> applicationException(ApplicationException e){
+    public ResponseEntity<ResponseDTO<Void>> applicationException(ApplicationException e) {
+        log.error("정의된 에러 : " + e.getErrorCode().getMessage(), e);
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(ResponseDTO.error(e.getErrorCode()));
+    }
+
+    /**
+     * @Valid 유효성 검사를 통과하지 못한 예외 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseDTO<Void>> handleValidationExceptions(MethodArgumentNotValidException e) {
+        BindingResult bindingResult = e.getBindingResult();
+        StringBuilder errorMessage = new StringBuilder();
+
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            errorMessage.append(String.format("%s - %s; ", fieldError.getField(), fieldError.getDefaultMessage()));
+            log.error("유효성 에러: " + errorMessage.toString(), fieldError);
+        }
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ResponseDTO.errorWithMessage(HttpStatus.BAD_REQUEST, errorMessage.toString()));
+    }
+
+
+    /**
+     * DB 관련 기타 예외 처리
+     */
+    @ExceptionHandler({DataAccessException.class})
+    public ResponseEntity<ResponseDTO<Void>> handleDataException(DataAccessException e) {
+        log.error("DB 에러 : " + e.getMessage(), e);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ResponseDTO.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage()));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ResponseDTO<Void>> serverException(RuntimeException e) {
+        log.error("정의되지 않은 에러 : " + e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ResponseDTO.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage()));
     }
 }

--- a/src/main/java/com/example/fastboard/global/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/example/fastboard/global/exception/GlobalExceptionAdvice.java
@@ -1,0 +1,17 @@
+package com.example.fastboard.global.exception;
+
+import com.example.fastboard.global.common.ResponseDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionAdvice {
+
+    @ExceptionHandler(ApplicationException.class)
+    public ResponseEntity<ResponseDTO<Void>> applicationException(ApplicationException e){
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ResponseDTO.error(e.getErrorCode()));
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>logs/fast-board-logger.log</file>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/fast-board-logger-%d{yyyy-MM-dd}.(%i).log</fileNamePattern>
+            <maxHistory>20</maxHistory>
+            <timeBasedFileNamingAndTriggeringPolicy
+                    class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+        </rollingPolicy>
+    </appender>
+
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <root level="info">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,33 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
+        <layout class="ch.qos.logback.classic.PatternLayout">
             <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
+        </layout>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/fast-board-logger.log</file>
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="RollingFile">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>
+                %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+            </pattern>
         </encoder>
+        <file>${LOGS}/fast-board-logger.log</file>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
         </filter>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>logs/fast-board-logger-%d{yyyy-MM-dd}.(%i).log</fileNamePattern>
+            <fileNamePattern>${LOGS}/archived/fast-board-logger-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxHistory>20</maxHistory>
             <timeBasedFileNamingAndTriggeringPolicy
                     class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>10MB</maxFileSize>
+                <maxFileSize>10KB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
     </appender>
 
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
 
+    <property name="LOGS" value="./logs"/>
+
     <root level="info">
         <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="RollingFile"/>
     </root>
 </configuration>

--- a/src/test/java/com/example/fastboard/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/fastboard/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,75 @@
+package com.example.fastboard.domain.member.service;
+
+import com.example.fastboard.domain.member.dto.request.MemberCreateRequest;
+import com.example.fastboard.domain.member.entity.Member;
+import com.example.fastboard.domain.member.exception.MemberAlreadyException;
+import com.example.fastboard.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("회원가입 성공")
+    public void 회원가입_성공() {
+        // given
+        MemberCreateRequest request = new MemberCreateRequest(
+                "test1",
+                "testNick",
+                "010-1111-111",
+                "test@test.com",
+                "12345678A`"
+        );
+
+        when(memberRepository.findByEmail(request.email())).thenReturn(Optional.empty());
+        when(memberRepository.findByNickname(request.nickname())).thenReturn(Optional.empty());
+        when(memberRepository.findByPhoneNumber(request.phoneNumber())).thenReturn(Optional.empty());
+
+        // when
+        memberService.signup(request);
+
+        // then
+        verify(memberRepository, times(1)).save(any(Member.class));
+        assertDoesNotThrow(() -> memberService.signup(request));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 이메일 중복")
+    public void 회원가입_실패_이메일_중복() {
+        // given
+        MemberCreateRequest request = new MemberCreateRequest(
+                "test1",
+                "testNick",
+                "010-1111-111",
+                "test@test.com",
+                "12345678A`"
+        );
+
+        Member existingMember = new Member();
+        when(memberRepository.findByEmail(request.email())).thenReturn(Optional.of(existingMember));
+
+        // when, then
+        assertThatThrownBy(() -> memberService.signup(request))
+                .isInstanceOf(MemberAlreadyException.class);
+    }
+}


### PR DESCRIPTION
### 로그백 설정
  - console과 rollingfile을 통해 로그를 남김
  - console 로그 레벨 : [info], rollingfile 로그 레벨 : [error]
  - ./logs/fast-board-logger.log 에 기록
  -  `<maxFileSize>10KB</maxFileSize>` : 파일 용량이 10KB가 넘으면 새 파일을 만들어 로깅하는 것을 말함, (연습용으로 10KB로 지정)
  - `<logger name="org.hibernate.SQL" level="DEBUG"/>` 해당 코드 누락 => 쿼리를 보고싶으면 추가
    
### 예외 처리
  - applicationException : 예측한 예외 처리
  - handleValidationExceptions : @Valid유효성 예외 처리
  - handleDataException : DB예외 처리
  - serverException : 그외 런타임 예외 처리
 
### 회원가입 기능 구현
- 클라이언트 요청 
- valid 유효성 검사 
- 사용가능한 이메일인지 확인(isAvailableEmail()) 
- unique검사 => (findByNickname, findByPhoneNumber)
- 저장 (repository.save())

#### 트러블 슈팅
- unique한 필드 검사를 어떻게 진행해야 할지 고민
  1.  예외 검사 없이 .save()를 하고 error가 발생하면 error에 대한 예외 처리 하기
  2.  select를 통해 미리 unique한 필드들에 대해 검사하기
  ```
    💡 결론은 2번 방법 선택, 이유는 1번 방법의 경우 세세한 에러 메시지를 컨트롤 하기 어려움 + 깅영한님..., 
      추가로 기능 측면에서 볼 때 회원가입 시 중복 검사는 별도 api로 비동기 통신을 하는 것이 대부분인 것 같고 
      별도 api로 구현하는게 맞다고 생각하기에 select를 2번 하더라도 그렇게 진행.
  ```    

### 테스트 코드 (추가 예정)
- service테스트
    - (성공) 구현 ㅇ
    - (실패) email 중복 구현 ㅇ
    - (성공) delete 회원 필터 구현 X 
    - (실패) nickname, phoneNumber 중복 구현 X
     
- controller 테스트

### 참고사항
```
1. 시큐리티 적용 전
2. 브랜치 이슈 발생 (develop에서 작업 브랜치 파서 작업한듯...)
3.  QueryDSL을 추후 적용하기 위해 MemberRepositoryCustom인터페이스와 구현체 클래스가 존재 (신경 안써도 괜찮습니다!)
```

### #️⃣ Issue Link - #1 