### PR TITLE
[refac] : Member Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.DS_Store
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	runtimeOnly 'com.h2database:h2'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	//Jwt

--- a/src/main/java/com/example/fastboard/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/fastboard/domain/member/controller/MemberController.java
@@ -33,7 +33,7 @@ public class MemberController {
     @PostMapping("/join")
     public ResponseEntity<ApiResponse<MemberSaveRes>> addMember(@RequestBody @Valid MemberSaveReq memberSaveReq) {
         Member member = memberSaveService.addMember(new MemberSaveParam(memberSaveReq));
-        MemberSaveRes memberSaveRes = new MemberSaveRes(member);
+        MemberSaveRes memberSaveRes = MemberSaveRes.of(member);
 
         return new ResponseEntity<>(new ApiResponse<>(HttpStatus.CREATED.value(), "회원가입에 성공하였습니다." ,memberSaveRes),HttpStatus.CREATED);
     }

--- a/src/main/java/com/example/fastboard/domain/member/dto/parameter/MemberSaveParam.java
+++ b/src/main/java/com/example/fastboard/domain/member/dto/parameter/MemberSaveParam.java
@@ -17,10 +17,10 @@ public class MemberSaveParam {
     private String password;
 
     public MemberSaveParam(MemberSaveReq memberSaveReq) {
-        this.name = memberSaveReq.getName();
-        this.nickname = memberSaveReq.getNickname();
-        this.phoneNumber = memberSaveReq.getPhoneNumber();
-        this.email = memberSaveReq.getEmail();
-        this.password = memberSaveReq.getPassword();
+        this.name = memberSaveReq.name();
+        this.nickname = memberSaveReq.nickname();
+        this.phoneNumber = memberSaveReq.phoneNumber();
+        this.email = memberSaveReq.email();
+        this.password = memberSaveReq.password();
     }
 }

--- a/src/main/java/com/example/fastboard/domain/member/dto/request/MemberLoginReq.java
+++ b/src/main/java/com/example/fastboard/domain/member/dto/request/MemberLoginReq.java
@@ -6,17 +6,14 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class MemberLoginReq {
-    @Email(message = "이메일 형식을 지켜주세요.")
-    @NotNull(message = "이메일을 입력해주세요.")
-    private String email;
+public record MemberLoginReq(
+        @Email(message = "이메일 형식을 지켜주세요.")
+        @NotNull(message = "이메일을 입력해주세요.")
+        String email,
 
-    @NotNull(message = "비밀번호를 입력해주세요.")
-    private String password;
-
-
+        @NotNull(message = "비밀번호를 입력해주세요.")
+        String password
+) {
     public MemberLoginParam toMemberLoginParam() {
         return new MemberLoginParam(this.email, this.password);
     }

--- a/src/main/java/com/example/fastboard/domain/member/dto/request/MemberSaveReq.java
+++ b/src/main/java/com/example/fastboard/domain/member/dto/request/MemberSaveReq.java
@@ -6,23 +6,21 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class MemberSaveReq {
-    @Email(message = "이메일 형식을 지켜주세요.")
-    @NotNull(message = "이메일을 입력해주세요.")
-    private String email;
+public record MemberSaveReq(
 
-    @NotBlank(message = "이름을 입력해주세요.")
-    @NotNull(message = "이름을 입력해주세요.")
-    private String name;
+        @Email(message = "이메일 형식을 지켜주세요.")
+        @NotNull(message = "이메일을 입력해주세요.")
+        String email,
 
-    @NotBlank(message = "비밀번호를 입력해주세요.")
-    @NotNull(message = "비밀번호를 입력해주세요.")
-    private String password;
+        @NotBlank(message = "이름을 입력해주세요.")
+        @NotNull(message = "이름을 입력해주세요.")
+        String name,
 
-    private String nickname;
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @NotNull(message = "비밀번호를 입력해주세요.")
+        String password,
 
-    private String phoneNumber;
+        String nickname,
 
-}
+        String phoneNumber
+) {}

--- a/src/main/java/com/example/fastboard/domain/member/dto/response/MemberSaveRes.java
+++ b/src/main/java/com/example/fastboard/domain/member/dto/response/MemberSaveRes.java
@@ -1,19 +1,16 @@
 package com.example.fastboard.domain.member.dto.response;
 
 import com.example.fastboard.domain.member.entity.Member;
-import lombok.Getter;
 
-@Getter
-public class MemberSaveRes {
-    private String name;
-    private String nickname;
-    private String phoneNumber;
-    private String email;
+public record MemberSaveRes(
+   String name,
+   String nickname,
+   String phoneNumber,
+   String email
+) {
 
-    public MemberSaveRes(Member member) {
-        this.name = member.getName();
-        this.nickname = member.getNickname();
-        this.phoneNumber = member.getPhoneNumber();
-        this.email = member.getEmail();
+    public static MemberSaveRes of(Member member) {
+        return new MemberSaveRes(member.getName(), member.getNickname(), member.getPhoneNumber(), member.getEmail());
     }
+
 }

--- a/src/main/java/com/example/fastboard/domain/member/entity/Member.java
+++ b/src/main/java/com/example/fastboard/domain/member/entity/Member.java
@@ -39,6 +39,17 @@ public class Member extends BaseEntitySoftDelete {
     private Role role;
 
     @Builder
+    public Member(Long id, String name, String nickname, String phoneNumber, String email, String encryptedPassword, Role role) {
+        this.id = id;
+        this.name = name;
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+        this.email = email;
+        this.encryptedPassword = encryptedPassword;
+        this.role = role;
+    }
+
+    @Builder
     public Member(String name, String nickname, String phoneNumber, String email, String encryptedPassword, Role role) {
         this.name = name;
         this.nickname = nickname;

--- a/src/test/java/com/example/fastboard/domain/member/service/MemberLoginTests.java
+++ b/src/test/java/com/example/fastboard/domain/member/service/MemberLoginTests.java
@@ -48,7 +48,6 @@ public class MemberLoginTests {
 
     public Member member() {
         return Member.builder()
-                .id(1L)
                 .name("TestName")
                 .email("TestEmail@email.com")
                 .nickname("TestNickname")

--- a/src/test/java/com/example/fastboard/domain/member/service/MemberSaveTests.java
+++ b/src/test/java/com/example/fastboard/domain/member/service/MemberSaveTests.java
@@ -51,7 +51,6 @@ public class MemberSaveTests {
 
         // given
         Member member = Member.builder()
-                .id(1L)
                 .name("TestName")
                 .email("TestEmail@email.com")
                 .nickname("TestNickname")
@@ -74,7 +73,6 @@ public class MemberSaveTests {
         Member savedMember = memberSaveService.addMember(memberSaveParam);
 
         // then
-        Assertions.assertNotNull(savedMember.getId());
         Assertions.assertEquals(member.getName(), savedMember.getName());
         Assertions.assertEquals(member.getEmail(), savedMember.getEmail());
         Assertions.assertEquals(member.getNickname(), savedMember.getNickname());
@@ -89,7 +87,6 @@ public class MemberSaveTests {
         // given
         MemberSaveParam memberSaveParam = memberSaveParam();
         Member member = Member.builder()
-                .id(1L)
                 .name(memberSaveParam.getName())
                 .email(memberSaveParam.getEmail())
                 .nickname(memberSaveParam.getNickname() + "salt")
@@ -114,7 +111,6 @@ public class MemberSaveTests {
         // given
         MemberSaveParam memberSaveParam = memberSaveParam();
         Member member = Member.builder()
-                .id(1L)
                 .name(memberSaveParam.getName())
                 .email(memberSaveParam.getEmail() + "salt")
                 .nickname(memberSaveParam.getNickname())
@@ -138,7 +134,6 @@ public class MemberSaveTests {
         // given
         MemberSaveParam memberSaveParam = memberSaveParam();
         Member member = Member.builder()
-                .id(1L)
                 .name(memberSaveParam.getName())
                 .email(memberSaveParam.getEmail() + "salt")
                 .nickname(memberSaveParam.getNickname() + "salt")

--- a/src/test/java/com/example/fastboard/domain/member/service/MemberSecurityTest.java
+++ b/src/test/java/com/example/fastboard/domain/member/service/MemberSecurityTest.java
@@ -1,0 +1,68 @@
+package com.example.fastboard.domain.member.service;
+
+import com.example.fastboard.domain.member.entity.Member;
+import com.example.fastboard.domain.member.entity.Role;
+import com.example.fastboard.global.common.auth.service.TokenService;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class MemberSecurityTest {
+
+    private static final Logger log = LoggerFactory.getLogger(MemberSecurityTest.class);
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    TokenService tokenService;
+
+    @Test
+    @WithAnonymousUser
+    public void get_anonymous() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/"))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.UNAUTHORIZED.value()));
+    }
+
+    @Test
+    public void get_user() throws Exception {
+        Member member = Member.builder()
+                .id(1L)
+                .name("user")
+                .role(Role.USER)
+                .email("test@email.com")
+                .build();
+        String token = tokenService.generateToken(member);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/").header("Authorization", "Bearer " + token))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.NOT_FOUND.value()));
+    }
+
+    @Test
+    public void get_user_admin() throws Exception {
+        Member member = Member.builder()
+                .id(1L)
+                .name("user")
+                .role(Role.USER)
+                .email("test@email.com")
+                .build();
+        String token = tokenService.generateToken(member);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/members/test").header("Authorization", "Bearer " + token))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.FORBIDDEN.value()));
+    }
+}

--- a/src/test/java/com/example/fastboard/domain/member/service/MemberSecurityTest.java
+++ b/src/test/java/com/example/fastboard/domain/member/service/MemberSecurityTest.java
@@ -3,12 +3,12 @@ package com.example.fastboard.domain.member.service;
 import com.example.fastboard.domain.member.entity.Member;
 import com.example.fastboard.domain.member.entity.Role;
 import com.example.fastboard.global.common.auth.service.TokenService;
+import com.example.fastboard.global.common.config.SecurityConfig;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,9 +19,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(SecurityConfig.class)
 public class MemberSecurityTest {
 
-    private static final Logger log = LoggerFactory.getLogger(MemberSecurityTest.class);
     @Autowired
     MockMvc mockMvc;
 


### PR DESCRIPTION
#### 목표
이번 주차를 진행하면서 그냥 넘어갔던 부분 또는 부족했던 부분들 리팩토링

#### 리팩토링 해야할 부분

- [x] Spring Security Test.
- [x] DTO Class -> Record Class.
- [x] Soft Delete 에 대한 점검.
- [ ] 코드 가독성 향상 

#### Soft Delete 에 대한 점검.
내가 채택한 방식은 `@where` 어노테이션을 사용하여 모든 쿼리 조건에 `deleted_at is null` 을 사용하는 것이다.
* 장점 : 모든 쿼리에 대해 기본적으로 조회 조건이 붙기 때문에 편리성 및 실수 방지.
* 단점 : 만약 삭제된 데이터를 조회하기 위해서는 nativeQuery 를 사용해야 한다
`native query를 직접 선언해서 실행하다 보면 JPA의 일부 장점들을 제대로 사용하지 못한다는 느낌이 있다. SQL을 직접 짜는 것 자체도 번거로운 일이고, SQL의 문법이 올바른지 실행 전에 확인하기 힘들다. 해당 쿼리가 특정 DB에만 종속되는 쿼리인지도 체크해보아야 한다.`


#### Spring Security Test
`@SpringBootTest`는 Spring의 전체 애플리케이션 컨텍스트를 로드합니다. 즉, 애플리케이션에서 사용되는 모든 빈(bean)을 로드하고, 실제처럼 내장 서버(예: 톰캣)를 구동하여 통합 테스트를 수행할 수 있습니다.

실제 서버가 실행되기 때문에, 애플리케이션의 전반적인 흐름(웹 요청, 데이터베이스, 보안 등)을 테스트할 수 있습니다.

`@WebMvcTest`는 **웹 계층(Controller, Filter 등)**만 테스트하기 위해 사용됩니다. 즉, 컨트롤러와 관련된 빈들만 로드하고, Spring의 필터 체인이나 보안 설정이 포함된 테스트를 할 수 있습니다.

그러나 이 경우, 실제 서버는 구동되지 않습니다. MockMvc라는 도구를 사용하여 서버 없이 HTTP 요청을 모의로 보내고 응답을 테스트할 수 있습니다.

#### SpringBootTest 를 선택한 이유
처음 WebMvcTest 를 활용하려고 했으나, SecurityConfig 클래스를 직접 등록하여 사용하려고 할 때, 이와 연관된 JwtFilter 그리고 또 다른 여러 연관관계의 서비스들로 인해 지속적인 오류가 발생했다. 즉, WebMvcTest 는 별도의 빈들을 가져오지 않기 때문에 이들을 모두 Mock 객체로 만들어서 임의의 행동을 정의해주어야 하는 불편함이 있어, SecurityTest 는 @SpringBootTest 를 사용하였다.

