### PR TITLE
[Feature] /boards 게시글 작성 기능 구현

### DIFF
--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -1,6 +1,7 @@
 package com.example.fastboard.domain.board.controller;
 
 import com.example.fastboard.domain.board.dto.request.BoardCreateRequest;
+import com.example.fastboard.domain.board.dto.response.BoardResponse;
 import com.example.fastboard.domain.board.service.BoardService;
 import com.example.fastboard.global.common.ResponseDTO;
 import jakarta.validation.Valid;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import java.util.List;
 
 @RestController
 @RequestMapping("/boards")
@@ -23,7 +25,16 @@ public class BoardController {
             Principal principal
     ) {
         Long memberId = Long.valueOf(principal.getName());
-        Long boardId = boardService.create(request, memberId);
+        Long boardId = boardService.save(request, memberId);
         return ResponseEntity.ok(ResponseDTO.okWithData(boardId));
+    }
+
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO<List<BoardResponse>>> getAllList() {
+        List<BoardResponse> allList = boardService.getAllBoards();
+        return ResponseEntity.ok(
+                ResponseDTO.okWithData(allList)
+        );
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -3,6 +3,7 @@ package com.example.fastboard.domain.board.controller;
 import com.example.fastboard.domain.board.dto.request.BoardCreateRequest;
 import com.example.fastboard.domain.board.service.BoardService;
 import com.example.fastboard.global.common.ResponseDTO;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,13 +19,11 @@ public class BoardController {
 
     @PostMapping
     public ResponseEntity<ResponseDTO<Long>> create(
-            @RequestBody BoardCreateRequest request,
+            @Valid @RequestBody BoardCreateRequest request,
             Principal principal
     ) {
         Long memberId = Long.valueOf(principal.getName());
         Long boardId = boardService.create(request, memberId);
-
         return ResponseEntity.ok(ResponseDTO.okWithData(boardId));
     }
-
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -1,0 +1,30 @@
+package com.example.fastboard.domain.board.controller;
+
+import com.example.fastboard.domain.board.dto.request.BoardCreateRequest;
+import com.example.fastboard.domain.board.service.BoardService;
+import com.example.fastboard.global.common.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/boards")
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @PostMapping
+    public ResponseEntity<ResponseDTO<Long>> create(
+            @RequestBody BoardCreateRequest request,
+            Principal principal
+    ) {
+        Long memberId = Long.valueOf(principal.getName());
+        Long boardId = boardService.create(request, memberId);
+
+        return ResponseEntity.ok(ResponseDTO.okWithData(boardId));
+    }
+
+}

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardImageController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardImageController.java
@@ -1,0 +1,30 @@
+package com.example.fastboard.domain.board.controller;
+
+import com.example.fastboard.domain.board.service.BoardImageService;
+import com.example.fastboard.global.common.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/images")
+public class BoardImageController {
+
+    private final BoardImageService boardImageService;
+
+    @PostMapping
+    public ResponseEntity<ResponseDTO<String>> upload(
+            MultipartFile file,
+            Principal principal
+    ) {
+        Long memberId = Long.valueOf(principal.getName());
+        String imgUrl = boardImageService.store(file, memberId);
+        return ResponseEntity.ok().body(ResponseDTO.okWithData(imgUrl));
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/dto/request/BoardCreateRequest.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/request/BoardCreateRequest.java
@@ -3,14 +3,18 @@ package com.example.fastboard.domain.board.dto.request;
 import com.example.fastboard.domain.board.entity.Board;
 import com.example.fastboard.domain.board.entity.Category;
 import com.example.fastboard.domain.member.entity.Member;
+import jakarta.validation.constraints.NotNull;
 
 public record BoardCreateRequest(
-    String title,
-    String content,
-    Category category
+        @NotNull(message = "제목을 입력해주세요")
+        String title,
+        @NotNull(message = "내용을 입력해주세요")
+        String content,
+        @NotNull(message = "카테고리를 선택해 주세요")
+        Category category
 ) {
 
-    public Board toEntity(Member member){
+    public Board toEntity(Member member) {
         return Board.builder()
                 .title(title)
                 .content(content)

--- a/src/main/java/com/example/fastboard/domain/board/dto/request/BoardCreateRequest.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/request/BoardCreateRequest.java
@@ -1,0 +1,22 @@
+package com.example.fastboard.domain.board.dto.request;
+
+import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.entity.Category;
+import com.example.fastboard.domain.member.entity.Member;
+
+public record BoardCreateRequest(
+    String title,
+    String content,
+    Category category
+) {
+
+    public Board toEntity(Member member){
+        return Board.builder()
+                .title(title)
+                .content(content)
+                .view(0L)
+                .category(category)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/dto/response/BoardResponse.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/response/BoardResponse.java
@@ -1,0 +1,30 @@
+package com.example.fastboard.domain.board.dto.response;
+
+import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.entity.Category;
+import com.example.fastboard.domain.member.entity.Member;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record BoardResponse(
+
+        String title,
+        String email,
+        Long view,
+        Long wish,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        LocalDateTime createdAt,
+        Category category
+) {
+    public static BoardResponse fromEntities(Board board, Member member) {
+        return new BoardResponse(
+                board.getTitle(),
+                member.getEmail(),
+                board.getView(),
+                (long) board.getWishes().size(),
+                board.getCreatedAt(),
+                board.getCategory()
+        );
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/entity/Board.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/Board.java
@@ -4,12 +4,15 @@ import com.example.fastboard.domain.member.entity.Member;
 import com.example.fastboard.domain.wish.entity.Wish;
 import com.example.fastboard.global.common.BaseEntitySoftDelete;
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 @NoArgsConstructor
 public class Board extends BaseEntitySoftDelete {
     @Id
@@ -21,6 +24,8 @@ public class Board extends BaseEntitySoftDelete {
     private String content;
     @Column(nullable = false)
     private Long view;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private Category category;
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;

--- a/src/main/java/com/example/fastboard/domain/board/entity/Board.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/Board.java
@@ -35,4 +35,24 @@ public class Board extends BaseEntitySoftDelete {
     private List<BoardComment> boardComments = new ArrayList<>();
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Wish> wishes = new ArrayList<>();
+
+    @Builder
+    private Board(
+            String title,
+            String content,
+            Long view, Category category,
+            Member member,
+            List<BoardImage> boardImages,
+            List<BoardComment> boardComments,
+            List<Wish> wishes
+    ) {
+        this.title = title;
+        this.content = content;
+        this.view = view;
+        this.category = category;
+        this.member = member;
+        this.boardImages = boardImages;
+        this.boardComments = boardComments;
+        this.wishes = wishes;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
@@ -21,4 +21,8 @@ public class BoardImage {
         this.saveName = saveName;
         this.board = board;
     }
+
+    public void setBoard(Board board) {
+        this.board = board;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
@@ -1,6 +1,7 @@
 package com.example.fastboard.domain.board.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -13,4 +14,11 @@ public class BoardImage {
     private String saveName;
     @ManyToOne(fetch = FetchType.LAZY)
     private Board board;
+
+    @Builder
+    private BoardImage(String originalName, String saveName, Board board) {
+        this.originalName = originalName;
+        this.saveName = saveName;
+        this.board = board;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/entity/Category.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/Category.java
@@ -4,8 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum Category {
-    FIRST("카테고리 1"),
-    SECOND("카테고리 2");
+    HUMOR("유머게시판"),
+    FOOTBALL("축구게시판");
 
     private final String categoryName;
 

--- a/src/main/java/com/example/fastboard/domain/board/exception/FileException.java
+++ b/src/main/java/com/example/fastboard/domain/board/exception/FileException.java
@@ -1,0 +1,13 @@
+package com.example.fastboard.domain.board.exception;
+
+import com.example.fastboard.global.exception.ApplicationException;
+import com.example.fastboard.global.exception.ErrorCode;
+
+public class FileException extends ApplicationException {
+    public FileException(ErrorCode errorCode){
+        super(errorCode);
+    }
+    public FileException(ErrorCode errorCode, Object data) {
+        super(errorCode, data);
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
@@ -3,5 +3,8 @@ package com.example.fastboard.domain.board.repository;
 import com.example.fastboard.domain.board.entity.BoardImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BoardImageRepository extends JpaRepository<BoardImage,Long> {
+    Optional<BoardImage> findBySaveName(String uniqueFileName);
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
@@ -1,0 +1,7 @@
+package com.example.fastboard.domain.board.repository;
+
+import com.example.fastboard.domain.board.entity.BoardImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardImageRepository extends JpaRepository<BoardImage,Long> {
+}

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
@@ -3,5 +3,8 @@ package com.example.fastboard.domain.board.repository;
 import com.example.fastboard.domain.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BoardRepository extends JpaRepository<Board,Long> {
+    List<Board> findAllByDeletedAtIsNull();
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
@@ -1,0 +1,7 @@
+package com.example.fastboard.domain.board.repository;
+
+import com.example.fastboard.domain.board.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board,Long> {
+}

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardImageService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardImageService.java
@@ -1,0 +1,105 @@
+package com.example.fastboard.domain.board.service;
+
+import com.example.fastboard.domain.board.entity.BoardImage;
+import com.example.fastboard.domain.board.exception.FileException;
+import com.example.fastboard.domain.board.repository.BoardImageRepository;
+import com.example.fastboard.domain.member.entity.Member;
+import com.example.fastboard.domain.member.service.MemberService;
+import com.example.fastboard.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class BoardImageService {
+
+    private final BoardImageRepository boardImageRepository;
+    private final MemberService memberService;
+
+    @Value("${file.dir}")
+    private String uploadDirectory;
+    private final static long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+    @Transactional
+    public String store(MultipartFile file, Long memberId) {
+        memberService.findActiveMemberById(memberId);
+
+        validateFile(file);
+        String originalFileName = file.getOriginalFilename();
+        if (originalFileName == null) {
+            throw new FileException(ErrorCode.FILE_ORIGINAL_NAME_IS_EMPTY_EXCEPTION);
+        }
+        String uniqueFileName = generateUniqueFileName(originalFileName);
+
+        Path filePath = Paths.get(uploadDirectory + File.separator + uniqueFileName);
+        createDirectoryIfNotExists(filePath.getParent());
+        saveFile(file, filePath);
+        saveBoardImage(originalFileName, uniqueFileName);  // BoardImage 저장
+        return filePath.toString();
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new FileException(ErrorCode.FILE_IS_EMPTY_EXCEPTION);
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new FileException(ErrorCode.FILE_SIZE_LIMIT_EXCEPTION);
+        }
+    }
+
+    private void createDirectoryIfNotExists(Path directoryPath) {
+        try {
+            if (Files.notExists(directoryPath)) {
+                Files.createDirectories(directoryPath);
+            }
+        } catch (IOException e) {
+            handleFileSystemException(e, directoryPath, "디렉토리 생성");
+        }
+    }
+
+    private void saveFile(MultipartFile file, Path filePath) {
+        try {
+            Files.copy(file.getInputStream(), filePath);
+        } catch (IOException e) {
+            handleFileSystemException(e, filePath, "파일 저장");
+        }
+    }
+
+    private BoardImage saveBoardImage(String originalFileName, String uniqueFileName) {
+        BoardImage boardImage = BoardImage.builder()
+                .originalName(originalFileName)
+                .saveName(uniqueFileName)
+                .build();
+        return boardImageRepository.save(boardImage);
+    }
+
+    private String generateUniqueFileName(String originalFileName) {
+        String extension = originalFileName.substring(originalFileName.lastIndexOf("."));
+        return UUID.randomUUID().toString() + extension;
+    }
+
+    private void handleFileSystemException(IOException e, Path path, String operation) {
+        if (e instanceof NoSuchFileException) {
+            log.error("{} 실패: 경로가 존재하지 않음: {}", operation, path, e);
+            throw new FileException(ErrorCode.PATH_NOT_FOUND, operation + " 경로가 존재하지 않음");
+        } else if (e instanceof FileAlreadyExistsException) {
+            log.error("{} 실패: 동일한 파일 또는 디렉토리가 이미 존재: {}", operation, path, e);
+            throw new FileException(ErrorCode.FILE_ALREADY_EXISTS, operation + " 동일한 파일/디렉토리 존재");
+        } else {
+            log.error("{} 실패: 알 수 없는 IO 에러 발생: {}", operation, path, e);
+            throw new FileException(ErrorCode.FILE_IOEXCEPTION, operation + " 실패");
+        }
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardImageService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardImageService.java
@@ -45,7 +45,13 @@ public class BoardImageService {
         Path filePath = Paths.get(uploadDirectory + File.separator + uniqueFileName);
         createDirectoryIfNotExists(filePath.getParent());
         saveFile(file, filePath);
-        saveBoardImage(originalFileName, uniqueFileName);  // BoardImage 저장
+
+        BoardImage boardImage = BoardImage.builder()
+                .originalName(originalFileName)
+                .saveName(uniqueFileName)
+                .build();
+        boardImageRepository.save(boardImage);
+
         return filePath.toString();
     }
 
@@ -75,14 +81,6 @@ public class BoardImageService {
         } catch (IOException e) {
             handleFileSystemException(e, filePath, "파일 저장");
         }
-    }
-
-    private BoardImage saveBoardImage(String originalFileName, String uniqueFileName) {
-        BoardImage boardImage = BoardImage.builder()
-                .originalName(originalFileName)
-                .saveName(uniqueFileName)
-                .build();
-        return boardImageRepository.save(boardImage);
     }
 
     private String generateUniqueFileName(String originalFileName) {

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardService.java
@@ -1,0 +1,24 @@
+package com.example.fastboard.domain.board.service;
+
+import com.example.fastboard.domain.board.dto.request.BoardCreateRequest;
+import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.repository.BoardRepository;
+import com.example.fastboard.domain.member.entity.Member;
+import com.example.fastboard.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+    private final MemberService memberService;
+
+    public Long create(BoardCreateRequest request, Long memberId) {
+        Member member = memberService.findActiveMemberById(memberId);
+        Board board = request.toEntity(member);
+        Board newBoard = boardRepository.save(board);
+        return newBoard.getId();
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardService.java
@@ -1,18 +1,32 @@
 package com.example.fastboard.domain.board.service;
 
 import com.example.fastboard.domain.board.dto.request.BoardCreateRequest;
+import com.example.fastboard.domain.board.dto.response.BoardResponse;
 import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.entity.BoardImage;
+import com.example.fastboard.domain.board.repository.BoardImageRepository;
 import com.example.fastboard.domain.board.repository.BoardRepository;
 import com.example.fastboard.domain.member.entity.Member;
 import com.example.fastboard.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class BoardService {
 
     private final BoardRepository boardRepository;
+    private final BoardImageRepository boardImageRepository;
     private final MemberService memberService;
 
     public Long create(BoardCreateRequest request, Long memberId) {
@@ -20,5 +34,11 @@ public class BoardService {
         Board board = request.toEntity(member);
         Board newBoard = boardRepository.save(board);
         return newBoard.getId();
+    }
+
+    public List<BoardResponse> getAllBoards() {
+        return boardRepository.findAllByDeletedAtIsNull().stream()
+                .map(board -> BoardResponse.fromEntities(board, board.getMember()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/fastboard/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/fastboard/domain/member/service/MemberService.java
@@ -49,6 +49,14 @@ public class MemberService {
         return true;
     }
 
+    public Member findActiveMemberById(Long id){
+        Member member = memberRepository.findById(id).orElseThrow(()-> new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION));
+        if(member.isDelete()){
+            throw new MemberException(ErrorCode.MEMBER_DELETED_EXCEPTION);
+        }
+        return member;
+    }
+
     public Member findActiveMemberByEmail(String email) {
         Member member = memberRepository.findByEmail(email).orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION));
         if (member.isDelete()) {

--- a/src/main/java/com/example/fastboard/global/config/UrlPermissionChecker.java
+++ b/src/main/java/com/example/fastboard/global/config/UrlPermissionChecker.java
@@ -31,7 +31,7 @@ public class UrlPermissionChecker {
     }
 
     public static final List<String> PERMIT_ALL_URIS = Arrays.asList(
-            "/h2-console/**"
+            "/api/h2-console/**"
     );
 
     public boolean isNeedAuthentication(String requestURI, String requestMethod) {

--- a/src/main/java/com/example/fastboard/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/fastboard/global/config/jwt/JwtAuthenticationFilter.java
@@ -26,18 +26,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String accessToken = extractToken(request);
 
         if (!urlPermissionChecker.isNeedAuthentication(request.getRequestURI(), request.getMethod())) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        // 토큰 유효성 검사 및 인증 객체 저장
-        if (StringUtils.hasText(accessToken)) {
-            Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-        }
+        String accessToken = extractToken(request);
+        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         filterChain.doFilter(request, response);
     }
@@ -52,8 +49,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 return token;
             }
             throw new AuthException(ErrorCode.AUTHORIZATION_HEADER_MUST_START_BEARER_EXCEPTION);
+        } else {
+            throw new AuthException(ErrorCode.UNAUTHORIZATION_EXCEPTION);
         }
-        return null;
     }
 
     private void validateExtractToken(String extractToken) {

--- a/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
@@ -30,6 +30,14 @@ public enum ErrorCode {
     TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST,"권한정보가 없는 토큰 입니다."),
     REFRESHTOKEN_NOT_FOUND(HttpStatus.NOT_FOUND,"refreshToken이 존재하지 않습니다."),
 
+    //FILE
+    FILE_IS_EMPTY_EXCEPTION(HttpStatus.BAD_REQUEST,"파일이 존재하지 않습니다."),
+    FILE_SIZE_LIMIT_EXCEPTION(HttpStatus.BAD_REQUEST,"파일 용량이 10MB를 초과할 수 없습니다." ),
+    FILE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,"이미 동일한 디렉토리 또는 파일 존재"),
+    PATH_NOT_FOUND(HttpStatus.BAD_REQUEST, "(Path)경로가 존재하지 않습니다."),
+    FILE_ORIGINAL_NAME_IS_EMPTY_EXCEPTION(HttpStatus.BAD_REQUEST,"원본 파일 이름이 NULL입니다."),
+    FILE_IOEXCEPTION(HttpStatus.BAD_REQUEST,"알 수 없는 이유로 처리에 실패 하였습니다."),
+
     //500 error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
 

--- a/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
@@ -38,6 +38,9 @@ public enum ErrorCode {
     FILE_ORIGINAL_NAME_IS_EMPTY_EXCEPTION(HttpStatus.BAD_REQUEST,"원본 파일 이름이 NULL입니다."),
     FILE_IOEXCEPTION(HttpStatus.BAD_REQUEST,"알 수 없는 이유로 처리에 실패 하였습니다."),
 
+    //BOARD_IMAGE
+    IMAGE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"이미지를 찾을 수 없습니다."),
+
     //500 error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -27,6 +27,9 @@ jwt:
     access-expiration-time: 180000    # 3분
     refresh-expiration-time: 6000000   # 10분
 
+file:
+  dir: C:\Users\ChangHoMoon\images
+
 server:
   port: 8080
 

--- a/src/test/java/com/example/fastboard/domain/board/service/BoardServiceTest.java
+++ b/src/test/java/com/example/fastboard/domain/board/service/BoardServiceTest.java
@@ -1,0 +1,61 @@
+package com.example.fastboard.domain.board.service;
+
+import com.example.fastboard.domain.board.dto.request.BoardCreateRequest;
+import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.entity.Category;
+import com.example.fastboard.domain.board.repository.BoardRepository;
+import com.example.fastboard.domain.member.entity.Member;
+import com.example.fastboard.domain.member.entity.Role;
+import com.example.fastboard.domain.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+public class BoardServiceTest {
+
+    @Mock
+    private MemberService memberService;
+    @Mock
+    private BoardRepository boardRepository;
+    @InjectMocks
+    private BoardService boardService;
+
+
+    @Test
+    @DisplayName("게시글 작성하기")
+    public void 게시글_작성(){
+        // given (데이터 준비)
+        Long memberId = 1L;
+        String title = "테스트 게시글";
+        String content = "<P>테스트 내용</p>";
+        Category category= Category.HUMOR;
+
+        BoardCreateRequest request = new BoardCreateRequest(title, content, category);
+
+        Member mockMember = Member.builder()
+                .role(Role.USER)
+                .build();
+
+        Board board = mock(Board.class);
+        when(memberService.findActiveMemberById(memberId)).thenReturn(mockMember);
+        when(boardRepository.save(any(Board.class))).thenReturn(board);
+        when(board.getId()).thenReturn(1L);
+
+        // when
+        Long boardId = boardService.create(request, memberId);
+
+        // then
+        assertDoesNotThrow(() -> boardService.create(request,memberId));
+        assertEquals(1L, boardId);
+    }
+}


### PR DESCRIPTION
### 게시글 작성
- `title` : String 타입 제목
- `content` : html 태그를 포함하는 문자열 형태로 저장
- `category` : enum타입 

### 벨리데이션 추가
- 모든 란에 대해 not null 추가

### 궁금한 점
** html 태그를 그대로 저장하는게 맞나?**
  - 편하지만 그대로 사용하기에 검색, 분석이 어렵다. 추후 검색엔진을 추가하게되어 document에 저장하게 되면 태그를 전부 지워주는 필터를 만들어 줘야 한다는 단점이 있음.
  - 그런데 태그가 없다면 문자 형식(ex. \<b>) 기억 할 수 없다.
  - 방법중에 json타입으로 {"type" : "text", "content":"test1".. "type" : "image", "content" : "경로"} 이런 방식으로  저장해서 순서를 기억하는 방법도 있는거 같은데 잘 모르겠다...
  
 ** 이미지 저장 처리 순서**
 ```
1. 게시글 텍스트 작성
2. 이미지 추가 -> 서버 s3/로컬 공간 에 저장 -> 경로 반환 -> <img src = " 경로 기록"> 
3. 게시글 텍스트 추가 작성
4. 게시글 저장 -> hmtl태그 그대로 content필드에 담겨서 전달

문제점 : 게시글이 취소될 경우 s3에 불필요한 이미지가 남아있음...
백엔드에서 이를 처리하는 추가적인 로직이 필요함. (내가 생각하는 최선...)
 ```
  - 프론트에서 게시글 작성 버튼 클릭 전 까지 어떤 일들이 일어나는지 궁금하다...