### PR TITLE
[Feature] /images 이미지 업로드 기능 구현

### DIFF
--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -1,6 +1,7 @@
 package com.example.fastboard.domain.board.controller;
 
 import com.example.fastboard.domain.board.dto.request.BoardCreateRequest;
+import com.example.fastboard.domain.board.dto.response.BoardResponse;
 import com.example.fastboard.domain.board.service.BoardService;
 import com.example.fastboard.global.common.ResponseDTO;
 import jakarta.validation.Valid;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import java.util.List;
 
 @RestController
 @RequestMapping("/boards")
@@ -23,7 +25,16 @@ public class BoardController {
             Principal principal
     ) {
         Long memberId = Long.valueOf(principal.getName());
-        Long boardId = boardService.create(request, memberId);
+        Long boardId = boardService.save(request, memberId);
         return ResponseEntity.ok(ResponseDTO.okWithData(boardId));
+    }
+
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO<List<BoardResponse>>> getAllList() {
+        List<BoardResponse> allList = boardService.getAllBoards();
+        return ResponseEntity.ok(
+                ResponseDTO.okWithData(allList)
+        );
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardImageController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardImageController.java
@@ -1,0 +1,30 @@
+package com.example.fastboard.domain.board.controller;
+
+import com.example.fastboard.domain.board.service.BoardImageService;
+import com.example.fastboard.global.common.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/images")
+public class BoardImageController {
+
+    private final BoardImageService boardImageService;
+
+    @PostMapping
+    public ResponseEntity<ResponseDTO<String>> upload(
+            MultipartFile file,
+            Principal principal
+    ) {
+        Long memberId = Long.valueOf(principal.getName());
+        String imgUrl = boardImageService.store(file, memberId);
+        return ResponseEntity.ok().body(ResponseDTO.okWithData(imgUrl));
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/dto/response/BoardResponse.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/response/BoardResponse.java
@@ -1,0 +1,30 @@
+package com.example.fastboard.domain.board.dto.response;
+
+import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.entity.Category;
+import com.example.fastboard.domain.member.entity.Member;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record BoardResponse(
+
+        String title,
+        String email,
+        Long view,
+        Long wish,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        LocalDateTime createdAt,
+        Category category
+) {
+    public static BoardResponse fromEntities(Board board, Member member) {
+        return new BoardResponse(
+                board.getTitle(),
+                member.getEmail(),
+                board.getView(),
+                (long) board.getWishes().size(),
+                board.getCreatedAt(),
+                board.getCategory()
+        );
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
@@ -21,4 +21,8 @@ public class BoardImage {
         this.saveName = saveName;
         this.board = board;
     }
+
+    public void setBoard(Board board) {
+        this.board = board;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
@@ -1,6 +1,7 @@
 package com.example.fastboard.domain.board.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -13,4 +14,11 @@ public class BoardImage {
     private String saveName;
     @ManyToOne(fetch = FetchType.LAZY)
     private Board board;
+
+    @Builder
+    private BoardImage(String originalName, String saveName, Board board) {
+        this.originalName = originalName;
+        this.saveName = saveName;
+        this.board = board;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/exception/FileException.java
+++ b/src/main/java/com/example/fastboard/domain/board/exception/FileException.java
@@ -1,0 +1,13 @@
+package com.example.fastboard.domain.board.exception;
+
+import com.example.fastboard.global.exception.ApplicationException;
+import com.example.fastboard.global.exception.ErrorCode;
+
+public class FileException extends ApplicationException {
+    public FileException(ErrorCode errorCode){
+        super(errorCode);
+    }
+    public FileException(ErrorCode errorCode, Object data) {
+        super(errorCode, data);
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
@@ -3,5 +3,8 @@ package com.example.fastboard.domain.board.repository;
 import com.example.fastboard.domain.board.entity.BoardImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BoardImageRepository extends JpaRepository<BoardImage,Long> {
+    Optional<BoardImage> findBySaveName(String uniqueFileName);
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
@@ -1,0 +1,7 @@
+package com.example.fastboard.domain.board.repository;
+
+import com.example.fastboard.domain.board.entity.BoardImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardImageRepository extends JpaRepository<BoardImage,Long> {
+}

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
@@ -3,5 +3,8 @@ package com.example.fastboard.domain.board.repository;
 import com.example.fastboard.domain.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BoardRepository extends JpaRepository<Board,Long> {
+    List<Board> findAllByDeletedAtIsNull();
 }

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardImageService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardImageService.java
@@ -1,0 +1,105 @@
+package com.example.fastboard.domain.board.service;
+
+import com.example.fastboard.domain.board.entity.BoardImage;
+import com.example.fastboard.domain.board.exception.FileException;
+import com.example.fastboard.domain.board.repository.BoardImageRepository;
+import com.example.fastboard.domain.member.entity.Member;
+import com.example.fastboard.domain.member.service.MemberService;
+import com.example.fastboard.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class BoardImageService {
+
+    private final BoardImageRepository boardImageRepository;
+    private final MemberService memberService;
+
+    @Value("${file.dir}")
+    private String uploadDirectory;
+    private final static long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+    @Transactional
+    public String store(MultipartFile file, Long memberId) {
+        memberService.findActiveMemberById(memberId);
+
+        validateFile(file);
+        String originalFileName = file.getOriginalFilename();
+        if (originalFileName == null) {
+            throw new FileException(ErrorCode.FILE_ORIGINAL_NAME_IS_EMPTY_EXCEPTION);
+        }
+        String uniqueFileName = generateUniqueFileName(originalFileName);
+
+        Path filePath = Paths.get(uploadDirectory + File.separator + uniqueFileName);
+        createDirectoryIfNotExists(filePath.getParent());
+        saveFile(file, filePath);
+        saveBoardImage(originalFileName, uniqueFileName);  // BoardImage 저장
+        return filePath.toString();
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new FileException(ErrorCode.FILE_IS_EMPTY_EXCEPTION);
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new FileException(ErrorCode.FILE_SIZE_LIMIT_EXCEPTION);
+        }
+    }
+
+    private void createDirectoryIfNotExists(Path directoryPath) {
+        try {
+            if (Files.notExists(directoryPath)) {
+                Files.createDirectories(directoryPath);
+            }
+        } catch (IOException e) {
+            handleFileSystemException(e, directoryPath, "디렉토리 생성");
+        }
+    }
+
+    private void saveFile(MultipartFile file, Path filePath) {
+        try {
+            Files.copy(file.getInputStream(), filePath);
+        } catch (IOException e) {
+            handleFileSystemException(e, filePath, "파일 저장");
+        }
+    }
+
+    private BoardImage saveBoardImage(String originalFileName, String uniqueFileName) {
+        BoardImage boardImage = BoardImage.builder()
+                .originalName(originalFileName)
+                .saveName(uniqueFileName)
+                .build();
+        return boardImageRepository.save(boardImage);
+    }
+
+    private String generateUniqueFileName(String originalFileName) {
+        String extension = originalFileName.substring(originalFileName.lastIndexOf("."));
+        return UUID.randomUUID().toString() + extension;
+    }
+
+    private void handleFileSystemException(IOException e, Path path, String operation) {
+        if (e instanceof NoSuchFileException) {
+            log.error("{} 실패: 경로가 존재하지 않음: {}", operation, path, e);
+            throw new FileException(ErrorCode.PATH_NOT_FOUND, operation + " 경로가 존재하지 않음");
+        } else if (e instanceof FileAlreadyExistsException) {
+            log.error("{} 실패: 동일한 파일 또는 디렉토리가 이미 존재: {}", operation, path, e);
+            throw new FileException(ErrorCode.FILE_ALREADY_EXISTS, operation + " 동일한 파일/디렉토리 존재");
+        } else {
+            log.error("{} 실패: 알 수 없는 IO 에러 발생: {}", operation, path, e);
+            throw new FileException(ErrorCode.FILE_IOEXCEPTION, operation + " 실패");
+        }
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardImageService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardImageService.java
@@ -45,7 +45,13 @@ public class BoardImageService {
         Path filePath = Paths.get(uploadDirectory + File.separator + uniqueFileName);
         createDirectoryIfNotExists(filePath.getParent());
         saveFile(file, filePath);
-        saveBoardImage(originalFileName, uniqueFileName);  // BoardImage 저장
+
+        BoardImage boardImage = BoardImage.builder()
+                .originalName(originalFileName)
+                .saveName(uniqueFileName)
+                .build();
+        boardImageRepository.save(boardImage);
+
         return filePath.toString();
     }
 
@@ -75,14 +81,6 @@ public class BoardImageService {
         } catch (IOException e) {
             handleFileSystemException(e, filePath, "파일 저장");
         }
-    }
-
-    private BoardImage saveBoardImage(String originalFileName, String uniqueFileName) {
-        BoardImage boardImage = BoardImage.builder()
-                .originalName(originalFileName)
-                .saveName(uniqueFileName)
-                .build();
-        return boardImageRepository.save(boardImage);
     }
 
     private String generateUniqueFileName(String originalFileName) {

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardService.java
@@ -1,18 +1,32 @@
 package com.example.fastboard.domain.board.service;
 
 import com.example.fastboard.domain.board.dto.request.BoardCreateRequest;
+import com.example.fastboard.domain.board.dto.response.BoardResponse;
 import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.entity.BoardImage;
+import com.example.fastboard.domain.board.repository.BoardImageRepository;
 import com.example.fastboard.domain.board.repository.BoardRepository;
 import com.example.fastboard.domain.member.entity.Member;
 import com.example.fastboard.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class BoardService {
 
     private final BoardRepository boardRepository;
+    private final BoardImageRepository boardImageRepository;
     private final MemberService memberService;
 
     public Long create(BoardCreateRequest request, Long memberId) {
@@ -20,5 +34,11 @@ public class BoardService {
         Board board = request.toEntity(member);
         Board newBoard = boardRepository.save(board);
         return newBoard.getId();
+    }
+
+    public List<BoardResponse> getAllBoards() {
+        return boardRepository.findAllByDeletedAtIsNull().stream()
+                .map(board -> BoardResponse.fromEntities(board, board.getMember()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
@@ -30,6 +30,14 @@ public enum ErrorCode {
     TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST,"권한정보가 없는 토큰 입니다."),
     REFRESHTOKEN_NOT_FOUND(HttpStatus.NOT_FOUND,"refreshToken이 존재하지 않습니다."),
 
+    //FILE
+    FILE_IS_EMPTY_EXCEPTION(HttpStatus.BAD_REQUEST,"파일이 존재하지 않습니다."),
+    FILE_SIZE_LIMIT_EXCEPTION(HttpStatus.BAD_REQUEST,"파일 용량이 10MB를 초과할 수 없습니다." ),
+    FILE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,"이미 동일한 디렉토리 또는 파일 존재"),
+    PATH_NOT_FOUND(HttpStatus.BAD_REQUEST, "(Path)경로가 존재하지 않습니다."),
+    FILE_ORIGINAL_NAME_IS_EMPTY_EXCEPTION(HttpStatus.BAD_REQUEST,"원본 파일 이름이 NULL입니다."),
+    FILE_IOEXCEPTION(HttpStatus.BAD_REQUEST,"알 수 없는 이유로 처리에 실패 하였습니다."),
+
     //500 error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
 

--- a/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
@@ -38,6 +38,9 @@ public enum ErrorCode {
     FILE_ORIGINAL_NAME_IS_EMPTY_EXCEPTION(HttpStatus.BAD_REQUEST,"원본 파일 이름이 NULL입니다."),
     FILE_IOEXCEPTION(HttpStatus.BAD_REQUEST,"알 수 없는 이유로 처리에 실패 하였습니다."),
 
+    //BOARD_IMAGE
+    IMAGE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"이미지를 찾을 수 없습니다."),
+
     //500 error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -27,6 +27,9 @@ jwt:
     access-expiration-time: 180000    # 3분
     refresh-expiration-time: 6000000   # 10분
 
+file:
+  dir: C:\Users\ChangHoMoon\images
+
 server:
   port: 8080
 


### PR DESCRIPTION
### 이미지 업로드 
1. 클라이언트 측에서 게시글 작성 중 이미지를 업로드 하게 되면 해당 api를 호출이 된다
2. 서버는 클라이언트로 받은 이미지를 로컬에 저장 한 후 저장 경로를  클라이언트에 리턴해준다.
3. 클라이언트는 경로를 받아서 <img src=""> 에 경로를 담아 게시글 저장 할 때 보내준다.
```
**위 방법을 사용하면 다음 문제들이 있다.**
게시글을 저장하지 않더라도 이미지는 별도로 서버에 저장이 되게된다.
만일 게시글을 최종 저장하지 않는다면 이미지는 필요없이 서버에 남아있게 되고, 이를 처리하는 로직을 추가해야한다.
(생각하기에 이 방법 말고 다른 방법이 있는지 모르겠음...)
```
 
### 설명 
- 멤버 조회
- 파일 유효성 검사(null,용량)
- 원본 파일명 get (비어있을 경우 예외 처리) 
- `generateUniqueFileName()` 유니크 파일명 생성 (UUID)
- 저장할 Path 지정
- 디렉토리 파일 없다면 생성
- `saveFile()` 파일 저장
- `saveBoardImage()` db에 이미지 이름 저장
- `return filePath` img가 저장된 경로 반환

### 생각할 부분
- Board와 BoardImage 연관관계 설정이 이뤄지지 않았다.
- content필드에 <img> 태그안에 필요한 이미지 경로가 저장되어 있어 불러오기를 할 수 있으나 게시글이 삭제될 때 관련 이미지들을 삭제할 수 가 없다.

### 해결 방안
- 최종 게시글 저장을 할 때,  \<img>태그 내에 src속성에 유니크한 파일이름을  파싱해서 고융한 이름을 가지고 boardId를 업데이트 해준다.
(성능 면에서 좋은 방법은 아닌거 같은데 다른 방법이 떠오르지 않는다)

💡테스트 코드 추가 예정