### PR TITLE
[Feature] /boards 게시글 전체 조회 & 게시판 이미지 처리 로직 수정

### DIFF
--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -1,6 +1,7 @@
 package com.example.fastboard.domain.board.controller;
 
 import com.example.fastboard.domain.board.dto.request.BoardCreateRequest;
+import com.example.fastboard.domain.board.dto.response.BoardResponse;
 import com.example.fastboard.domain.board.service.BoardService;
 import com.example.fastboard.global.common.ResponseDTO;
 import jakarta.validation.Valid;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import java.util.List;
 
 @RestController
 @RequestMapping("/boards")
@@ -23,7 +25,16 @@ public class BoardController {
             Principal principal
     ) {
         Long memberId = Long.valueOf(principal.getName());
-        Long boardId = boardService.create(request, memberId);
+        Long boardId = boardService.save(request, memberId);
         return ResponseEntity.ok(ResponseDTO.okWithData(boardId));
+    }
+
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO<List<BoardResponse>>> getAllList() {
+        List<BoardResponse> allList = boardService.getAllBoards();
+        return ResponseEntity.ok(
+                ResponseDTO.okWithData(allList)
+        );
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/dto/response/BoardResponse.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/response/BoardResponse.java
@@ -1,0 +1,30 @@
+package com.example.fastboard.domain.board.dto.response;
+
+import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.entity.Category;
+import com.example.fastboard.domain.member.entity.Member;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record BoardResponse(
+
+        String title,
+        String email,
+        Long view,
+        Long wish,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        LocalDateTime createdAt,
+        Category category
+) {
+    public static BoardResponse fromEntities(Board board, Member member) {
+        return new BoardResponse(
+                board.getTitle(),
+                member.getEmail(),
+                board.getView(),
+                (long) board.getWishes().size(),
+                board.getCreatedAt(),
+                board.getCategory()
+        );
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
@@ -21,4 +21,8 @@ public class BoardImage {
         this.saveName = saveName;
         this.board = board;
     }
+
+    public void setBoard(Board board) {
+        this.board = board;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
@@ -3,5 +3,8 @@ package com.example.fastboard.domain.board.repository;
 import com.example.fastboard.domain.board.entity.BoardImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BoardImageRepository extends JpaRepository<BoardImage,Long> {
+    Optional<BoardImage> findBySaveName(String uniqueFileName);
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
@@ -3,5 +3,8 @@ package com.example.fastboard.domain.board.repository;
 import com.example.fastboard.domain.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BoardRepository extends JpaRepository<Board,Long> {
+    List<Board> findAllByDeletedAtIsNull();
 }

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardService.java
@@ -1,18 +1,32 @@
 package com.example.fastboard.domain.board.service;
 
 import com.example.fastboard.domain.board.dto.request.BoardCreateRequest;
+import com.example.fastboard.domain.board.dto.response.BoardResponse;
 import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.entity.BoardImage;
+import com.example.fastboard.domain.board.repository.BoardImageRepository;
 import com.example.fastboard.domain.board.repository.BoardRepository;
 import com.example.fastboard.domain.member.entity.Member;
 import com.example.fastboard.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class BoardService {
 
     private final BoardRepository boardRepository;
+    private final BoardImageRepository boardImageRepository;
     private final MemberService memberService;
 
     public Long create(BoardCreateRequest request, Long memberId) {
@@ -20,5 +34,11 @@ public class BoardService {
         Board board = request.toEntity(member);
         Board newBoard = boardRepository.save(board);
         return newBoard.getId();
+    }
+
+    public List<BoardResponse> getAllBoards() {
+        return boardRepository.findAllByDeletedAtIsNull().stream()
+                .map(board -> BoardResponse.fromEntities(board, board.getMember()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/fastboard/global/exception/ErrorCode.java
@@ -38,6 +38,9 @@ public enum ErrorCode {
     FILE_ORIGINAL_NAME_IS_EMPTY_EXCEPTION(HttpStatus.BAD_REQUEST,"원본 파일 이름이 NULL입니다."),
     FILE_IOEXCEPTION(HttpStatus.BAD_REQUEST,"알 수 없는 이유로 처리에 실패 하였습니다."),
 
+    //BOARD_IMAGE
+    IMAGE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"이미지를 찾을 수 없습니다."),
+
     //500 error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
 


### PR DESCRIPTION
### 게시글 전체 조회

### 이미지 처리 로직 변경
- 지난 [pr](https://github.com/fast-board/be_board/pull/28)에 언급한 것 처럼 로직 수정
- 분명 content내부 데이터를 매번 파싱해야 한다는 단점이 있어 좋은 방식은 아닌것 같다.