### PR TITLE
[Feature] GET boards/{boardId} 게시글 상세 보기 기능 구현

### DIFF
--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -2,6 +2,7 @@ package com.example.fastboard.domain.board.controller;
 
 import com.example.fastboard.domain.board.dto.request.BoardCreateRequest;
 import com.example.fastboard.domain.board.dto.request.BoardUpdateRequest;
+import com.example.fastboard.domain.board.dto.response.BoardDetailResponse;
 import com.example.fastboard.domain.board.dto.response.BoardResponse;
 import com.example.fastboard.domain.board.service.BoardService;
 import com.example.fastboard.global.common.ResponseDTO;
@@ -36,6 +37,17 @@ public class BoardController {
         List<BoardResponse> allList = boardService.getAllBoards();
         return ResponseEntity.ok(
                 ResponseDTO.okWithData(allList)
+        );
+    }
+
+    @GetMapping("{boardId}")
+    public ResponseEntity<ResponseDTO<BoardDetailResponse>> getDetail(
+            @PathVariable Long boardId,
+            Principal principal
+    ) {
+        Long memberId = Long.valueOf(principal.getName());
+        return ResponseEntity.ok(
+                ResponseDTO.okWithData(boardService.loadBoardDetail(boardId, memberId))
         );
     }
 

--- a/src/main/java/com/example/fastboard/domain/board/dto/response/BoardCommentResponse.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/response/BoardCommentResponse.java
@@ -1,0 +1,21 @@
+package com.example.fastboard.domain.board.dto.response;
+
+import com.example.fastboard.domain.board.entity.BoardComment;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record BoardCommentResponse(
+        String email,
+        String content,
+        List<BoardCommentResponse> childComments,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        LocalDateTime createdAt
+) {
+
+    public static BoardCommentResponse fromEntity(BoardComment boardComment) {
+        // 댓글 기능 구현 후 추가 예정
+        return null;
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/dto/response/BoardDetailResponse.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/response/BoardDetailResponse.java
@@ -1,0 +1,43 @@
+package com.example.fastboard.domain.board.dto.response;
+
+import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.entity.Category;
+import com.example.fastboard.domain.member.entity.Member;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record BoardDetailResponse(
+
+        String title,
+        String email,
+        String content,
+        Long view,
+        Long wish,
+        List<BoardCommentResponse> boardComments,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        LocalDateTime createdAt,
+        Category category
+) {
+    public static BoardDetailResponse fromEntities(Board board) {
+        /**
+         * 댓글 작성 기능 구현 후 추가 개발 예정.
+         */
+        List<BoardCommentResponse> commentResponses = board.getBoardComments().stream()
+                .map(BoardCommentResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        return new BoardDetailResponse(
+                board.getTitle(),
+                board.getMember().getEmail(),
+                board.getContent(),
+                board.getView(),
+                (long) board.getWishes().size(),
+                commentResponses,
+                board.getCreatedAt(),
+                board.getCategory()
+        );
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/entity/Board.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/Board.java
@@ -62,4 +62,8 @@ public class Board extends BaseEntitySoftDelete {
         this.content=content;
         this.category=category;
     }
+
+    public void plusViewCount(){
+        this.view+=1;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/entity/BoardComment.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/BoardComment.java
@@ -3,12 +3,15 @@ package com.example.fastboard.domain.board.entity;
 import com.example.fastboard.domain.member.entity.Member;
 import com.example.fastboard.global.common.BaseEntitySoftDelete;
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 @NoArgsConstructor
 public class BoardComment extends BaseEntitySoftDelete {
     @Id
@@ -24,4 +27,13 @@ public class BoardComment extends BaseEntitySoftDelete {
     private BoardComment parentComment;     //부모 댓글
     @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BoardComment> childComments = new ArrayList<>();
+
+    @Builder
+    private BoardComment(String content, Board parentBoard, Member member, BoardComment parentComment, List<BoardComment> childComments) {
+        this.content = content;
+        this.parentBoard = parentBoard;
+        this.member = member;
+        this.parentComment = parentComment;
+        this.childComments = childComments;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardService.java
@@ -2,6 +2,7 @@ package com.example.fastboard.domain.board.service;
 
 import com.example.fastboard.domain.board.dto.request.BoardCreateRequest;
 import com.example.fastboard.domain.board.dto.request.BoardUpdateRequest;
+import com.example.fastboard.domain.board.dto.response.BoardDetailResponse;
 import com.example.fastboard.domain.board.dto.response.BoardResponse;
 import com.example.fastboard.domain.board.entity.Board;
 import com.example.fastboard.domain.board.entity.BoardImage;
@@ -97,7 +98,20 @@ public class BoardService {
     }
 
     public Board findActiveBoardById(Long boardId) {
-        return boardRepository.findById(boardId)
-                .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION));
+        Board board = boardRepository.findById(boardId).orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION));
+        if (board.isDelete()) {
+            throw new BoardException(ErrorCode.BOARD_DELETED_EXCEPTION);
+        }
+        return board;
+    }
+
+    @Transactional
+    public BoardDetailResponse loadBoardDetail(Long boardId, Long memberId) {
+        memberService.findActiveMemberById(memberId);
+        Board board = findActiveBoardById(boardId);
+        if (!board.getMember().getId().equals(memberId)) {
+            board.plusViewCount();
+        }
+        return BoardDetailResponse.fromEntities(board);
     }
 }


### PR DESCRIPTION
###  게시글 상세 보기
1. `boardId`, `memberId` 값을 기준으로 게시글과 게시글에 접근하고자 하는 회원을 찾는다.
2. 게시글 작성자와 접근하려는 회원이 같다면 조회수는 증가시키지 않는다.
3. 해당 게시글에 대한 정보를 response dto에 담아서 보내준다.
※ 댓글 관련 정보는 댓글 기능 구현 후 추가할 예정.


### 추가
- 게시글 업데이트 작업을 chang브랜치에서 하는 바람에 pr 못올리고 바로 병합 되버렸습니다..! 비즈니스 로직은 다음이 전부고 상세 보시려면 chang 브랜치에서 마지막 commit 내역 보시면 볼 수 있습니다!
![image](https://github.com/user-attachments/assets/a61e1760-ce0e-4fec-b555-284b594e61bb)
