### PR TITLE
[Feature] PUT /api/boards/{board_id} 게시글 수정

### DIFF
--- a/src/main/java/com/example/fastboard/FastBoardApplication.java
+++ b/src/main/java/com/example/fastboard/FastBoardApplication.java
@@ -2,10 +2,12 @@ package com.example.fastboard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableJpaAuditing
 public class FastBoardApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -7,11 +7,12 @@ import com.example.fastboard.domain.board.dto.response.BoardGetRes;
 import com.example.fastboard.domain.board.dto.response.BoardPageRes;
 import com.example.fastboard.domain.board.dto.response.BoardPostRes;
 import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.service.BoardDeleteService;
 import com.example.fastboard.domain.board.service.BoardGetService;
 import com.example.fastboard.domain.board.service.BoardPostService;
 import com.example.fastboard.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,6 +28,7 @@ public class BoardController {
 
     private final BoardPostService boardPostService;
     private final BoardGetService boardGetService;
+    private final BoardDeleteService boardDeleteService;
 
     @PostMapping
     public ResponseEntity<ApiResponse> post(@RequestBody BoardPostReq boardPostReq, Principal principal) {
@@ -92,8 +94,16 @@ public class BoardController {
         Board board = boardPostService.update(boardUpdateParam);
 
         BoardPostRes boardPostRes = new BoardPostRes(board.getMember().getName(), board.getId(), board.getTitle(), board.getContent());
-        ApiResponse response = new ApiResponse(HttpStatus.CREATED.value(), "게시글이 생성되었습니다.", boardPostRes);
+        ApiResponse response = new ApiResponse(HttpStatus.OK.value(), "게시글이 수정되었습니다..", boardPostRes);
 
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<ApiResponse> delete(@PathVariable Long boardId, Principal principal) {
+        boardDeleteService.deleteBoard(boardId);
+        ApiResponse response = new ApiResponse(HttpStatus.NO_CONTENT.value(), "게시글이 삭제되었습니다.", null);
+        return new ResponseEntity<>(response, HttpStatus.NO_CONTENT);
+
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -1,5 +1,7 @@
 package com.example.fastboard.domain.board.controller;
 
+import com.example.fastboard.domain.board.dto.parameter.BoardPostParam;
+import com.example.fastboard.domain.board.dto.parameter.BoardUpdateParam;
 import com.example.fastboard.domain.board.dto.request.BoardPostReq;
 import com.example.fastboard.domain.board.dto.response.BoardGetRes;
 import com.example.fastboard.domain.board.dto.response.BoardPageRes;
@@ -74,5 +76,24 @@ public class BoardController {
 
         ApiResponse response = new ApiResponse(HttpStatus.OK.value(), null, boardPostResList);
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PutMapping("/{boardId}")
+    public ResponseEntity<ApiResponse> update(@PathVariable Long boardId, @RequestBody BoardPostParam boardPostParam, Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        BoardUpdateParam boardUpdateParam = BoardUpdateParam.builder()
+                .boardId(boardId)
+                .category(boardPostParam.category())
+                .content(boardPostParam.content())
+                .authorId(userId)
+                .title(boardPostParam.title())
+                .build();
+
+        Board board = boardPostService.update(boardUpdateParam);
+
+        BoardPostRes boardPostRes = new BoardPostRes(board.getMember().getName(), board.getId(), board.getTitle(), board.getContent());
+        ApiResponse response = new ApiResponse(HttpStatus.CREATED.value(), "게시글이 생성되었습니다.", boardPostRes);
+
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -104,6 +104,5 @@ public class BoardController {
         boardDeleteService.deleteBoard(boardId);
         ApiResponse response = new ApiResponse(HttpStatus.NO_CONTENT.value(), "게시글이 삭제되었습니다.", null);
         return new ResponseEntity<>(response, HttpStatus.NO_CONTENT);
-
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/dto/parameter/BoardUpdateParam.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/parameter/BoardUpdateParam.java
@@ -1,0 +1,17 @@
+package com.example.fastboard.domain.board.dto.parameter;
+
+import com.example.fastboard.domain.board.entity.Category;
+import lombok.Builder;
+
+@Builder
+public record BoardUpdateParam(
+        Long boardId,
+        String title,
+        String content,
+        Long authorId,
+        Category category
+) {
+    static BoardUpdateParam of(Long boardId, String title, String content, Long authorId, Category category) {
+        return new BoardUpdateParam(boardId, title, content, authorId, category);
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/entity/Board.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/Board.java
@@ -61,4 +61,16 @@ public class Board extends BaseEntitySoftDelete {
     public void updateView(Long view) {
         this.view = view;
     }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
@@ -4,10 +4,13 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor
 @Getter
+@SQLDelete(sql = "UPDATE board_image SET board_id = null WHERE id = ?")
 public class BoardImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
@@ -1,5 +1,6 @@
 package com.example.fastboard.domain.board.entity;
 
+import com.example.fastboard.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,8 +11,8 @@ import org.hibernate.annotations.Where;
 @Entity
 @NoArgsConstructor
 @Getter
-@SQLDelete(sql = "UPDATE board_image SET board_id = null WHERE id = ?")
-public class BoardImage {
+@SQLDelete(sql = "UPDATE board_image SET board_id = null, deleted_at = now() WHERE id = ?")
+public class BoardImage extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/example/fastboard/domain/board/exception/BoardErrorCode.java
+++ b/src/main/java/com/example/fastboard/domain/board/exception/BoardErrorCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum BoardErrorCode implements ErrorCode {
     IMAGE_UPLOAD_FAIL("이미지 업로드에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     IMAGE_NOT_FOUND("이미지를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    MEMBER_NOT_EQUAL("게시글의 작성자가 압니니다.", HttpStatus.BAD_REQUEST),
     BOARD_NOT_FOUND("해당 게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
 

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -18,4 +19,10 @@ public interface BoardImageRepository extends JpaRepository<BoardImage, Long> {
 
     @Modifying
     void deleteBoardImageByBoardId(Long boardId);
+
+    List<BoardImage> findBoardImageByBoardIsNullAndUpdatedAtBefore(LocalDateTime updatedAt);
+
+    @Modifying
+    @Query(nativeQuery = true, value = "DELETE FROM BOARD_IMAGE WHERE id IN :boardImageIdList")
+    void deleteBoardImageByIdList(List<Long> boardImageIdList);
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
@@ -13,6 +13,9 @@ import java.util.List;
 public interface BoardImageRepository extends JpaRepository<BoardImage, Long> {
 
     @Modifying
-    @Query("update BoardImage B set B.board.id = :boardId where B.id in :boardImageIdList")
+    @Query("UPDATE BoardImage B SET B.board.id = :boardId WHERE B.id IN :boardImageIdList")
     void updateBoardImage(@Param("boardImageIdList")List<Long> boardImageIdList, @Param("boardId") Long boardId);
+
+    @Modifying
+    void deleteBoardImageByBoardId(Long boardId);
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
@@ -22,4 +22,5 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("UPDATE Board B SET B.view = :view WHERE B.id = :id")
     @Modifying
     void updateViewById(Long id, Long view);
+
 }

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardDeleteService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardDeleteService.java
@@ -1,0 +1,17 @@
+package com.example.fastboard.domain.board.service;
+
+import com.example.fastboard.domain.board.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardDeleteService {
+    private final BoardRepository boardRepository;
+    private final BoardImageDeleteService boardImageDeleteService;
+
+    public void deleteBoard(Long boardId) {
+        boardRepository.deleteById(boardId);
+        boardImageDeleteService.deleteByBoardId(boardId);
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardImageDeleteService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardImageDeleteService.java
@@ -1,9 +1,19 @@
 package com.example.fastboard.domain.board.service;
 
+import com.example.fastboard.domain.board.entity.BoardImage;
 import com.example.fastboard.domain.board.repository.BoardImageRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,4 +25,46 @@ public class BoardImageDeleteService {
     public void deleteByBoardId(Long boardId) {
         boardImageRepository.deleteBoardImageByBoardId(boardId);
     }
+
+    /**
+     * Schedule
+     */
+    /**
+     * Schedule
+     */
+//    @Scheduled(fixedDelay = 1000 * 60 * 60 * 24)
+    @Scheduled(fixedDelay = 5000)
+    @Async("imageDeleter")
+    @Modifying
+    @Transactional
+    public void deleteImageNotConnectedBoard() {
+        LocalDateTime cutoffTime = LocalDateTime.now().minusHours(24);
+        List<BoardImage> boardImages = boardImageRepository.findBoardImageByBoardIsNullAndUpdatedAtBefore(cutoffTime);
+        List<Long> ids = new ArrayList<>();
+
+        // File Delete.
+        for (BoardImage boardImage : boardImages) {
+            Path path = Path.of(boardImage.getSaveName());
+            File file = path.toFile();
+
+            // 파일이 성공적으로 삭제되었는지 확인
+            if (file.exists()) {
+                boolean isDeleted = file.delete();
+                if (isDeleted) {
+                    ids.add(boardImage.getId());
+                } else {
+                    // 파일 삭제 실패 시 예외 로그 기록
+                    System.err.println("Failed to delete file: " + boardImage.getSaveName());
+                }
+            } else {
+                System.err.println("File not found: " + boardImage.getSaveName());
+            }
+        }
+
+        // 파일 삭제가 성공한 이미지들만 RDB 삭제
+        if (!ids.isEmpty()) {
+            boardImageRepository.deleteBoardImageByIdList(ids);
+        }
+    }
+
 }

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardImageDeleteService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardImageDeleteService.java
@@ -1,0 +1,18 @@
+package com.example.fastboard.domain.board.service;
+
+import com.example.fastboard.domain.board.repository.BoardImageRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardImageDeleteService {
+    private final BoardImageRepository boardImageRepository;
+
+
+    @Transactional
+    public void deleteByBoardId(Long boardId) {
+        boardImageRepository.deleteBoardImageByBoardId(boardId);
+    }
+}


### PR DESCRIPTION
#### Flow
생성과 마찬가지인 `BoardPostReq`을 Request DTO로 사용한다.
이후 해당 DTO를 활용하여, `BoardUpdateParam` 을 생성하여, 이를 update 메서드에 전달한다.

1. 요청한 유저와 Board 의 작성자 ID를 비교한다. (Board Select Query)
2. 만약, 다르다면 에러를 반환한다.
3. 해당 보드와 기존 연결되어 있던 이미지들의 연관관계를 끊는다. (BoardImage Update Query)
4. 새롭게 파싱한 이미지들의 아이디들을 다시 연관관계로 이어준다. (BoardImage Set Query)
5. 변경사항을 Board Entity 에 반영하고 저장한다. (Board Update Query)

#### 고려사항
어떻게 하면 이 4번의 쿼리를 줄일 수 있을까 . . .??