### PR TITLE
[Feature] DELETE /api/boards/{board_id}

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.24.3'
 
 	//lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/fastboard/FastBoardApplication.java
+++ b/src/main/java/com/example/fastboard/FastBoardApplication.java
@@ -2,8 +2,10 @@ package com.example.fastboard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class FastBoardApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/fastboard/FastBoardApplication.java
+++ b/src/main/java/com/example/fastboard/FastBoardApplication.java
@@ -2,10 +2,12 @@ package com.example.fastboard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableJpaAuditing
 public class FastBoardApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -2,17 +2,21 @@ package com.example.fastboard.domain.board.controller;
 
 import com.example.fastboard.domain.board.dto.request.BoardPostReq;
 import com.example.fastboard.domain.board.dto.response.BoardGetRes;
+import com.example.fastboard.domain.board.dto.response.BoardPageRes;
 import com.example.fastboard.domain.board.dto.response.BoardPostRes;
 import com.example.fastboard.domain.board.entity.Board;
 import com.example.fastboard.domain.board.service.BoardGetService;
 import com.example.fastboard.domain.board.service.BoardPostService;
 import com.example.fastboard.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/boards")
@@ -46,6 +50,29 @@ public class BoardController {
                 .build();
 
         ApiResponse response = new ApiResponse(HttpStatus.OK.value(), null, boardGetRes);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse> getBoardList(@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
+                                                    @RequestParam(required = false, defaultValue = "createdAt", value = "criteria") String criteria) {
+        List<Board> boards = boardGetService.getBoardList(pageNo, criteria);
+
+        List<BoardPageRes> boardPostResList = new ArrayList<>();
+        for (Board board : boards) {
+            BoardPageRes res = BoardPageRes.builder()
+                    .id(board.getId())
+                    .commentCount(board.getCommentCount())
+                    .content(board.getContent())
+                    .view(board.getView())
+                    .wishCount(board.getWishCount())
+                    .title(board.getTitle())
+                    .build();
+
+            boardPostResList.add(res);
+        }
+
+        ApiResponse response = new ApiResponse(HttpStatus.OK.value(), null, boardPostResList);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -7,11 +7,12 @@ import com.example.fastboard.domain.board.dto.response.BoardGetRes;
 import com.example.fastboard.domain.board.dto.response.BoardPageRes;
 import com.example.fastboard.domain.board.dto.response.BoardPostRes;
 import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.service.BoardDeleteService;
 import com.example.fastboard.domain.board.service.BoardGetService;
 import com.example.fastboard.domain.board.service.BoardPostService;
 import com.example.fastboard.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,6 +28,7 @@ public class BoardController {
 
     private final BoardPostService boardPostService;
     private final BoardGetService boardGetService;
+    private final BoardDeleteService boardDeleteService;
 
     @PostMapping
     public ResponseEntity<ApiResponse> post(@RequestBody BoardPostReq boardPostReq, Principal principal) {
@@ -92,8 +94,16 @@ public class BoardController {
         Board board = boardPostService.update(boardUpdateParam);
 
         BoardPostRes boardPostRes = new BoardPostRes(board.getMember().getName(), board.getId(), board.getTitle(), board.getContent());
-        ApiResponse response = new ApiResponse(HttpStatus.CREATED.value(), "게시글이 생성되었습니다.", boardPostRes);
+        ApiResponse response = new ApiResponse(HttpStatus.OK.value(), "게시글이 수정되었습니다..", boardPostRes);
 
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<ApiResponse> delete(@PathVariable Long boardId, Principal principal) {
+        boardDeleteService.deleteBoard(boardId);
+        ApiResponse response = new ApiResponse(HttpStatus.NO_CONTENT.value(), "게시글이 삭제되었습니다.", null);
+        return new ResponseEntity<>(response, HttpStatus.NO_CONTENT);
+
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -29,5 +29,4 @@ public class BoardController {
 
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
-
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -29,4 +29,10 @@ public class BoardController {
 
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
+
+    @GetMapping("/{boardId}")
+    public ResponseEntity<ApiResponse> getBoard(@PathVariable Long boardId) {
+
+        return null;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -1,5 +1,7 @@
 package com.example.fastboard.domain.board.controller;
 
+import com.example.fastboard.domain.board.dto.parameter.BoardPostParam;
+import com.example.fastboard.domain.board.dto.parameter.BoardUpdateParam;
 import com.example.fastboard.domain.board.dto.request.BoardPostReq;
 import com.example.fastboard.domain.board.dto.response.BoardGetRes;
 import com.example.fastboard.domain.board.dto.response.BoardPageRes;
@@ -74,5 +76,24 @@ public class BoardController {
 
         ApiResponse response = new ApiResponse(HttpStatus.OK.value(), null, boardPostResList);
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PutMapping("/{boardId}")
+    public ResponseEntity<ApiResponse> update(@PathVariable Long boardId, @RequestBody BoardPostParam boardPostParam, Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        BoardUpdateParam boardUpdateParam = BoardUpdateParam.builder()
+                .boardId(boardId)
+                .category(boardPostParam.category())
+                .content(boardPostParam.content())
+                .authorId(userId)
+                .title(boardPostParam.title())
+                .build();
+
+        Board board = boardPostService.update(boardUpdateParam);
+
+        BoardPostRes boardPostRes = new BoardPostRes(board.getMember().getName(), board.getId(), board.getTitle(), board.getContent());
+        ApiResponse response = new ApiResponse(HttpStatus.CREATED.value(), "게시글이 생성되었습니다.", boardPostRes);
+
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -104,6 +104,5 @@ public class BoardController {
         boardDeleteService.deleteBoard(boardId);
         ApiResponse response = new ApiResponse(HttpStatus.NO_CONTENT.value(), "게시글이 삭제되었습니다.", null);
         return new ResponseEntity<>(response, HttpStatus.NO_CONTENT);
-
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -1,8 +1,10 @@
 package com.example.fastboard.domain.board.controller;
 
 import com.example.fastboard.domain.board.dto.request.BoardPostReq;
+import com.example.fastboard.domain.board.dto.response.BoardGetRes;
 import com.example.fastboard.domain.board.dto.response.BoardPostRes;
 import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.service.BoardGetService;
 import com.example.fastboard.domain.board.service.BoardPostService;
 import com.example.fastboard.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ import java.security.Principal;
 public class BoardController {
 
     private final BoardPostService boardPostService;
+    private final BoardGetService boardGetService;
 
     @PostMapping
     public ResponseEntity<ApiResponse> post(@RequestBody BoardPostReq boardPostReq, Principal principal) {
@@ -32,7 +35,17 @@ public class BoardController {
 
     @GetMapping("/{boardId}")
     public ResponseEntity<ApiResponse> getBoard(@PathVariable Long boardId) {
+        Board board = boardGetService.getBoard(boardId);
+        BoardGetRes boardGetRes = BoardGetRes.builder()
+                .id(boardId)
+                .author(board.getMember().getNickname())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .view(board.getView())
+                .authorId(board.getMember().getId())
+                .build();
 
-        return null;
+        ApiResponse response = new ApiResponse(HttpStatus.OK.value(), null, boardGetRes);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardImageController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardImageController.java
@@ -26,7 +26,6 @@ import java.nio.file.Files;
 @RequiredArgsConstructor
 public class BoardImageController {
 
-
     public final BoardImagePostService boardImagePostService;
     public final BoardImageGetService boardImageGetService;
 
@@ -51,6 +50,7 @@ public class BoardImageController {
             return ResponseEntity.ok().header("Content-type",Files.probeContentType(image.toPath())).body(FileCopyUtils.copyToByteArray(image));
         } catch (IOException e) {
             e.printStackTrace();
+            log.error("이미지를 불러오는데 실패하였습니다.");
             return null;
         }
     }

--- a/src/main/java/com/example/fastboard/domain/board/dto/parameter/BoardUpdateParam.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/parameter/BoardUpdateParam.java
@@ -1,0 +1,17 @@
+package com.example.fastboard.domain.board.dto.parameter;
+
+import com.example.fastboard.domain.board.entity.Category;
+import lombok.Builder;
+
+@Builder
+public record BoardUpdateParam(
+        Long boardId,
+        String title,
+        String content,
+        Long authorId,
+        Category category
+) {
+    static BoardUpdateParam of(Long boardId, String title, String content, Long authorId, Category category) {
+        return new BoardUpdateParam(boardId, title, content, authorId, category);
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/dto/response/BoardGetRes.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/response/BoardGetRes.java
@@ -1,0 +1,13 @@
+package com.example.fastboard.domain.board.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record BoardGetRes(
+        Long id,
+        Long authorId,
+        String author,
+        String title,
+        String content,
+        Long view
+) {}

--- a/src/main/java/com/example/fastboard/domain/board/dto/response/BoardPageRes.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/response/BoardPageRes.java
@@ -1,0 +1,14 @@
+package com.example.fastboard.domain.board.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record BoardPageRes(
+        Long id,
+        String title,
+        String content,
+        Long view,
+        int commentCount,
+        int wishCount
+) {
+}

--- a/src/main/java/com/example/fastboard/domain/board/entity/Board.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/Board.java
@@ -61,4 +61,16 @@ public class Board extends BaseEntitySoftDelete {
     public void updateView(Long view) {
         this.view = view;
     }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/entity/Board.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/Board.java
@@ -7,6 +7,9 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +17,8 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor
+@SQLDelete(sql = "UPDATE board SET deleted_at = now() WHERE id = ?")
+@Where(clause = "deleted_at is null")
 public class Board extends BaseEntitySoftDelete {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,10 +35,18 @@ public class Board extends BaseEntitySoftDelete {
     private Member member;
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BoardImage> boardImages = new ArrayList<>();
+
     @OneToMany(mappedBy = "parentBoard", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BoardComment> boardComments = new ArrayList<>();
+
+    @Formula("(select count(*) from board_comment where board_comment.parent_board_id = id)")
+    private int commentCount;
+
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Wish> wishes = new ArrayList<>();
+
+    @Formula("(select count(*) from wish where wish.board_id = id)")
+    private int wishCount;
 
 
     @Builder

--- a/src/main/java/com/example/fastboard/domain/board/entity/Board.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/Board.java
@@ -44,4 +44,8 @@ public class Board extends BaseEntitySoftDelete {
         this.category = category;
         this.view = 0L;
     }
+
+    public void updateView(Long view) {
+        this.view = view;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
@@ -4,10 +4,13 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor
 @Getter
+@SQLDelete(sql = "UPDATE board_image SET board_id = null WHERE id = ?")
 public class BoardImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/BoardImage.java
@@ -1,5 +1,6 @@
 package com.example.fastboard.domain.board.entity;
 
+import com.example.fastboard.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,8 +11,8 @@ import org.hibernate.annotations.Where;
 @Entity
 @NoArgsConstructor
 @Getter
-@SQLDelete(sql = "UPDATE board_image SET board_id = null WHERE id = ?")
-public class BoardImage {
+@SQLDelete(sql = "UPDATE board_image SET board_id = null, deleted_at = now() WHERE id = ?")
+public class BoardImage extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/example/fastboard/domain/board/exception/BoardErrorCode.java
+++ b/src/main/java/com/example/fastboard/domain/board/exception/BoardErrorCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum BoardErrorCode implements ErrorCode {
     IMAGE_UPLOAD_FAIL("이미지 업로드에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     IMAGE_NOT_FOUND("이미지를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    MEMBER_NOT_EQUAL("게시글의 작성자가 압니니다.", HttpStatus.BAD_REQUEST),
     BOARD_NOT_FOUND("해당 게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
 

--- a/src/main/java/com/example/fastboard/domain/board/exception/BoardErrorCode.java
+++ b/src/main/java/com/example/fastboard/domain/board/exception/BoardErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum BoardErrorCode implements ErrorCode {
     IMAGE_UPLOAD_FAIL("이미지 업로드에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    IMAGE_NOT_FOUND("이미지를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    IMAGE_NOT_FOUND("이미지를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    BOARD_NOT_FOUND("해당 게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
 
     private final String message;

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -18,4 +19,10 @@ public interface BoardImageRepository extends JpaRepository<BoardImage, Long> {
 
     @Modifying
     void deleteBoardImageByBoardId(Long boardId);
+
+    List<BoardImage> findBoardImageByBoardIsNullAndUpdatedAtBefore(LocalDateTime updatedAt);
+
+    @Modifying
+    @Query(nativeQuery = true, value = "DELETE FROM BOARD_IMAGE WHERE id IN :boardImageIdList")
+    void deleteBoardImageByIdList(List<Long> boardImageIdList);
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardImageRepository.java
@@ -13,6 +13,9 @@ import java.util.List;
 public interface BoardImageRepository extends JpaRepository<BoardImage, Long> {
 
     @Modifying
-    @Query("update BoardImage B set B.board.id = :boardId where B.id in :boardImageIdList")
+    @Query("UPDATE BoardImage B SET B.board.id = :boardId WHERE B.id IN :boardImageIdList")
     void updateBoardImage(@Param("boardImageIdList")List<Long> boardImageIdList, @Param("boardId") Long boardId);
+
+    @Modifying
+    void deleteBoardImageByBoardId(Long boardId);
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
@@ -22,4 +22,5 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("UPDATE Board B SET B.view = :view WHERE B.id = :id")
     @Modifying
     void updateViewById(Long id, Long view);
+
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
@@ -1,6 +1,8 @@
 package com.example.fastboard.domain.board.repository;
 
 import com.example.fastboard.domain.board.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,6 +15,9 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query("SELECT B FROM Board B JOIN FETCH B.member WHERE B.id = :id")
     Optional<Board> findById(Long id);
+
+    @Query("SELECT B FROM Board B JOIN FETCH B.member ")
+    Page<Board> findAll(Pageable pageable);
 
     @Query("UPDATE Board B SET B.view = :view WHERE B.id = :id")
     @Modifying

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
@@ -2,6 +2,7 @@ package com.example.fastboard.domain.board.repository;
 
 import com.example.fastboard.domain.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -10,6 +11,10 @@ import java.util.Optional;
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
-    @Query("select B FROM Board B JOIN FETCH B.member WHERE B.id = :id")
+    @Query("SELECT B FROM Board B JOIN FETCH B.member WHERE B.id = :id")
     Optional<Board> findById(Long id);
+
+    @Query("UPDATE Board B SET B.view = :view WHERE B.id = :id")
+    @Modifying
+    void updateViewById(Long id, Long view);
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
@@ -2,8 +2,14 @@ package com.example.fastboard.domain.board.repository;
 
 import com.example.fastboard.domain.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    @Query("select B FROM Board B JOIN FETCH B.member")
+    Optional<Board> findById(Long id);
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
-    @Query("select B FROM Board B JOIN FETCH B.member")
+    @Query("select B FROM Board B JOIN FETCH B.member WHERE B.id = :id")
     Optional<Board> findById(Long id);
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/ViewRedisRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/ViewRedisRepository.java
@@ -2,36 +2,71 @@ package com.example.fastboard.domain.board.repository;
 
 import com.example.fastboard.domain.board.entity.Board;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.*;
 import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor
 public class ViewRedisRepository {
     private final RedisTemplate<String, Long> longRedisTemplate;
     private final String PRE_FIX = "boardView:";
+    private final RedissonClient redissonClient;
 
-    public Long get(Long id) {
-        ValueOperations<String, Long> ops = longRedisTemplate.opsForValue();
-        Long view = ops.get(PRE_FIX + id);
 
-        if (view != null) {
-            return view;
+    public Long get(Board board) {
+        RLock lock = redissonClient.getLock("ViewRLock" + board.getId());
+
+        try {
+            boolean available = lock.tryLock(5, 1, TimeUnit.SECONDS);
+
+            if (!available) {
+                return board.getView();
+            }
+
+            Long view = longRedisTemplate.opsForValue().get(PRE_FIX + board.getId());
+
+            if (view == null) {
+                longRedisTemplate.opsForValue().set(PRE_FIX + board.getId(), board.getView() + 1);
+                return board.getView() + 1;
+            }
+
+            else {
+                longRedisTemplate.opsForValue().set(PRE_FIX + board.getId(), view + 1);
+                return view + 1;
+            }
+        } catch(InterruptedException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        } finally {
+            lock.unlock();
         }
-        return null;
     }
 
-    public Long saveWithIncrement(Board board) {
-        ValueOperations<String, Long> ops = longRedisTemplate.opsForValue();
-        ops.set(PRE_FIX + board.getId(), board.getView() + 1);
+    public Set<String> getKeysWithScan() {
+        Set<String> keys = new HashSet<>();
+        Cursor<byte[]> cursor = longRedisTemplate.executeWithStickyConnection(redisConnection ->
+                redisConnection.scan(ScanOptions.scanOptions().match(PRE_FIX + "*").count(1000).build())
+        );
 
-        return get(board.getId());
+        while (cursor.hasNext()) {
+            keys.add(new String(cursor.next()));
+        }
+        cursor.close();
+        return keys;
     }
 
-    public Long updateWithIncrement(Long id, Long view) {
-        ValueOperations<String, Long> ops = longRedisTemplate.opsForValue();
-        ops.set(PRE_FIX + id, view + 1);
-        return view + 1;
+    public Long getViewByKey(String key) {
+        return longRedisTemplate.opsForValue().get(key);
     }
+
+    public void deleteByKey(String key) {
+        longRedisTemplate.delete(key);
+    }
+
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/ViewRedisRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/ViewRedisRepository.java
@@ -1,0 +1,37 @@
+package com.example.fastboard.domain.board.repository;
+
+import com.example.fastboard.domain.board.entity.Board;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ViewRedisRepository {
+    private final RedisTemplate<String, Long> longRedisTemplate;
+    private final String PRE_FIX = "boardView:";
+
+    public Long get(Long id) {
+        ValueOperations<String, Long> ops = longRedisTemplate.opsForValue();
+        Long view = ops.get(PRE_FIX + id);
+
+        if (view != null) {
+            return view;
+        }
+        return null;
+    }
+
+    public Long saveWithIncrement(Board board) {
+        ValueOperations<String, Long> ops = longRedisTemplate.opsForValue();
+        ops.set(PRE_FIX + board.getId(), board.getView() + 1);
+
+        return get(board.getId());
+    }
+
+    public Long updateWithIncrement(Long id, Long view) {
+        ValueOperations<String, Long> ops = longRedisTemplate.opsForValue();
+        ops.set(PRE_FIX + id, view + 1);
+        return view + 1;
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardDeleteService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardDeleteService.java
@@ -1,0 +1,17 @@
+package com.example.fastboard.domain.board.service;
+
+import com.example.fastboard.domain.board.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardDeleteService {
+    private final BoardRepository boardRepository;
+    private final BoardImageDeleteService boardImageDeleteService;
+
+    public void deleteBoard(Long boardId) {
+        boardRepository.deleteById(boardId);
+        boardImageDeleteService.deleteByBoardId(boardId);
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardGetService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardGetService.java
@@ -16,16 +16,8 @@ public class BoardGetService {
 
     public Board getBoard(Long boardId) {
         Board board = boardRepository.findById(boardId).orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
-        Long viewCount = viewRedisRepository.get(board.getId());
-
         // 조회수 처리 by Redis.
-        if (viewCount == null) {
-            viewCount = viewRedisRepository.saveWithIncrement(board);
-        }
-
-        else {
-            viewCount = viewRedisRepository.updateWithIncrement(board.getId(), viewCount);
-        }
+        Long viewCount = viewRedisRepository.get(board);
 
         board.updateView(viewCount);
         return board;

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardGetService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardGetService.java
@@ -6,7 +6,12 @@ import com.example.fastboard.domain.board.exception.BoardException;
 import com.example.fastboard.domain.board.repository.ViewRedisRepository;
 import com.example.fastboard.domain.board.repository.BoardRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,5 +26,10 @@ public class BoardGetService {
 
         board.updateView(viewCount);
         return board;
+    }
+
+    public List<Board> getBoardList(int pageNo, String criteria) {
+        Pageable pageable = PageRequest.of(pageNo, 10, Sort.by(Sort.Direction.DESC, criteria));
+        return boardRepository.findAll(pageable).getContent();
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardGetService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardGetService.java
@@ -3,6 +3,7 @@ package com.example.fastboard.domain.board.service;
 import com.example.fastboard.domain.board.entity.Board;
 import com.example.fastboard.domain.board.exception.BoardErrorCode;
 import com.example.fastboard.domain.board.exception.BoardException;
+import com.example.fastboard.domain.board.repository.ViewRedisRepository;
 import com.example.fastboard.domain.board.repository.BoardRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,16 +12,22 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class BoardGetService {
     private final BoardRepository boardRepository;
+    private final ViewRedisRepository viewRedisRepository;
 
     public Board getBoard(Long boardId) {
         Board board = boardRepository.findById(boardId).orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
+        Long viewCount = viewRedisRepository.get(board.getId());
 
+        // 조회수 처리 by Redis.
+        if (viewCount == null) {
+            viewCount = viewRedisRepository.saveWithIncrement(board);
+        }
 
+        else {
+            viewCount = viewRedisRepository.updateWithIncrement(board.getId(), viewCount);
+        }
+
+        board.updateView(viewCount);
         return board;
-    }
-
-    public Board getBoards() {
-
-        return null;
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardGetService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardGetService.java
@@ -1,0 +1,26 @@
+package com.example.fastboard.domain.board.service;
+
+import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.exception.BoardErrorCode;
+import com.example.fastboard.domain.board.exception.BoardException;
+import com.example.fastboard.domain.board.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardGetService {
+    private final BoardRepository boardRepository;
+
+    public Board getBoard(Long boardId) {
+        Board board = boardRepository.findById(boardId).orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
+
+
+        return board;
+    }
+
+    public Board getBoards() {
+
+        return null;
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardImageDeleteService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardImageDeleteService.java
@@ -1,9 +1,19 @@
 package com.example.fastboard.domain.board.service;
 
+import com.example.fastboard.domain.board.entity.BoardImage;
 import com.example.fastboard.domain.board.repository.BoardImageRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,4 +25,46 @@ public class BoardImageDeleteService {
     public void deleteByBoardId(Long boardId) {
         boardImageRepository.deleteBoardImageByBoardId(boardId);
     }
+
+    /**
+     * Schedule
+     */
+    /**
+     * Schedule
+     */
+//    @Scheduled(fixedDelay = 1000 * 60 * 60 * 24)
+    @Scheduled(fixedDelay = 5000)
+    @Async("imageDeleter")
+    @Modifying
+    @Transactional
+    public void deleteImageNotConnectedBoard() {
+        LocalDateTime cutoffTime = LocalDateTime.now().minusHours(24);
+        List<BoardImage> boardImages = boardImageRepository.findBoardImageByBoardIsNullAndUpdatedAtBefore(cutoffTime);
+        List<Long> ids = new ArrayList<>();
+
+        // File Delete.
+        for (BoardImage boardImage : boardImages) {
+            Path path = Path.of(boardImage.getSaveName());
+            File file = path.toFile();
+
+            // 파일이 성공적으로 삭제되었는지 확인
+            if (file.exists()) {
+                boolean isDeleted = file.delete();
+                if (isDeleted) {
+                    ids.add(boardImage.getId());
+                } else {
+                    // 파일 삭제 실패 시 예외 로그 기록
+                    System.err.println("Failed to delete file: " + boardImage.getSaveName());
+                }
+            } else {
+                System.err.println("File not found: " + boardImage.getSaveName());
+            }
+        }
+
+        // 파일 삭제가 성공한 이미지들만 RDB 삭제
+        if (!ids.isEmpty()) {
+            boardImageRepository.deleteBoardImageByIdList(ids);
+        }
+    }
+
 }

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardImageDeleteService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardImageDeleteService.java
@@ -1,0 +1,18 @@
+package com.example.fastboard.domain.board.service;
+
+import com.example.fastboard.domain.board.repository.BoardImageRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardImageDeleteService {
+    private final BoardImageRepository boardImageRepository;
+
+
+    @Transactional
+    public void deleteByBoardId(Long boardId) {
+        boardImageRepository.deleteBoardImageByBoardId(boardId);
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardImageGetService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardImageGetService.java
@@ -6,14 +6,11 @@ import com.example.fastboard.domain.board.exception.BoardException;
 import com.example.fastboard.domain.board.repository.BoardImageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.UrlResource;
+
 import org.springframework.stereotype.Service;
 
 import java.io.File;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.nio.file.Paths;
+
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/example/fastboard/domain/board/service/BoardPostService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/BoardPostService.java
@@ -21,10 +21,8 @@ public class BoardPostService {
     private final BoardImagePostService boardImagePostService;
     private final MemberFindService memberFindService;
 
-
     @Transactional
     public Board create(BoardPostParam boardPostParam) {
-
         Member member = memberFindService.findMemberById(boardPostParam.authorId());
         List<Long> images = getImageId(boardPostParam.content());
 
@@ -35,7 +33,7 @@ public class BoardPostService {
                 .category(boardPostParam.category())
                 .build());
 
-        boardImagePostService.connectToBoard(images, board.getId());
+        if (images.size() > 0) boardImagePostService.connectToBoard(images, board.getId());
         return board;
     }
 

--- a/src/main/java/com/example/fastboard/domain/board/service/ViewScheduleService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/ViewScheduleService.java
@@ -1,0 +1,36 @@
+package com.example.fastboard.domain.board.service;
+
+import com.example.fastboard.domain.board.repository.BoardRepository;
+import com.example.fastboard.domain.board.repository.ViewRedisRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ViewScheduleService {
+    private final ViewRedisRepository viewRedisRepository;
+    private final BoardRepository boardRepository;
+
+    @Scheduled(fixedDelay = 5000L)
+    @Async("viewCountExecutor")
+    @Transactional
+    public void viewSchedule() {
+        Set<String> keys = viewRedisRepository.getKeysWithScan();
+        keys.forEach(key -> {
+
+            Long id = Long.parseLong(key.substring(key.lastIndexOf(":") + 1));
+            Long viewCount = viewRedisRepository.getViewByKey(key);
+            if (viewCount != null) {
+                boardRepository.updateViewById(id, viewCount);
+                viewRedisRepository.deleteByKey(key);
+            }
+        });
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/fastboard/domain/member/controller/MemberController.java
@@ -48,8 +48,6 @@ public class MemberController {
         return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK.value(),null, memberLoginService.reissue(refreshToken.refreshToken())));
     }
 
-
-
     @GetMapping("/test")
     public void test() {
         UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/src/main/java/com/example/fastboard/domain/member/entity/Member.java
+++ b/src/main/java/com/example/fastboard/domain/member/entity/Member.java
@@ -2,7 +2,6 @@ package com.example.fastboard.domain.member.entity;
 
 import com.example.fastboard.global.common.entity.BaseEntitySoftDelete;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/fastboard/domain/member/service/MemberFindService.java
+++ b/src/main/java/com/example/fastboard/domain/member/service/MemberFindService.java
@@ -1,5 +1,6 @@
 package com.example.fastboard.domain.member.service;
 
+import com.example.fastboard.domain.board.service.BoardImagePostService;
 import com.example.fastboard.domain.member.entity.Member;
 import com.example.fastboard.domain.member.exception.MemberErrorCode;
 import com.example.fastboard.domain.member.exception.MemberException;

--- a/src/main/java/com/example/fastboard/global/common/config/RedisConfig.java
+++ b/src/main/java/com/example/fastboard/global/common/config/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -30,6 +31,16 @@ public class RedisConfig {
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, Long> redisTemplateLong() {
+        RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new GenericToStringSerializer<Long>(Long.class));
         return redisTemplate;
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,13 +1,13 @@
 spring:
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test
-    username: sa
-    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/fast_board?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: 251414
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       format_sql: true
     show-sql: true


### PR DESCRIPTION
#### 생각한 점
특정 보드를 삭제하는 경우, 해당 보드와 관련된 이미지들의 참조 키를 NULL로 만들었다.  
이후, Scheudler 를 통해 updated_at 이 현재 날짜와 하루 이상 차이나는 이미지 엔티티들을 조회한 후, 이미지 경로에 해당하는 파일들을 삭제하고, 이미지 엔티티 또한 삭제하는 로직으로 구현하였다. (Hard Delete)
