### PR TITLE
[feat] 검색엔진 추가 (결과 출력만 확인)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// es
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,68 @@ services:
     volumes:
       - redis_data:/data
 
+
+  es01:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
+    container_name: es01
+    environment:
+      - node.name=es01
+      - cluster.name=es-docker-cluster
+      - discovery.seed_hosts=es02
+      - cluster.initial_master_nodes=es01,es02
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - data01:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - elastic
+
+  es02:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
+    container_name: es02
+    environment:
+      - node.name=es02
+      - cluster.name=es-docker-cluster
+      - discovery.seed_hosts=es01
+      - cluster.initial_master_nodes=es01,es02
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - data02:/usr/share/elasticsearch/data
+    ports:
+      - 9201:9201
+    networks:
+      - elastic
+
+  kib01:
+    image: docker.elastic.co/kibana/kibana:7.17.0
+    container_name: kib01
+    ports:
+      - 5601:5601
+    environment:
+      ELASTICSEARCH_URL: http://es01:9200
+      ELASTICSEARCH_HOSTS: http://es01:9200
+    networks:
+      - elastic
+
 volumes:
   mysql_data:
   redis_data:
+  data01:
+    driver: local
+  data02:
+    driver: local
+
+networks:
+  elastic:
+    driver: bridge

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -90,13 +90,4 @@ public class BoardController {
         return ResponseEntity.ok(ResponseDTO.ok());
     }
 
-    @GetMapping("/test/{id}")
-    public ResponseEntity<ResponseDTO<Board>> test(
-            @PathVariable Long id
-    ) {
-        Board test = boardService.test(id);
-        return ResponseEntity.ok(
-                ResponseDTO.okWithData(test)
-        );
-    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/dto/BoardMapper.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/BoardMapper.java
@@ -1,0 +1,22 @@
+package com.example.fastboard.domain.board.dto;
+
+import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.entity.BoardDocument;
+
+public class BoardMapper {
+    public static BoardDocument toDocument(Board board) {
+        if (board == null) {
+            return null;
+        }
+
+        return new BoardDocument(
+                String.valueOf(board.getId()),
+                board.getTitle(),
+                board.getContent(),
+                board.getMember().getNickname(), // 작성자의 닉네임을 가져옴
+                (long) board.getWishes().size(),
+                board.getView(), // 조회 수
+                board.getCategory().name() // 카테고리 (이름으로 변환)
+        );
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/entity/BoardDocument.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/BoardDocument.java
@@ -1,0 +1,34 @@
+package com.example.fastboard.domain.board.entity;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Getter
+@Setter
+@Document(indexName = "boards")
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardDocument {
+
+    @Id
+    @Field(type = FieldType.Keyword)
+    private String id;  //es 문서 식별자
+    @Field(type = FieldType.Text)
+    private String title;  // 게시글 제목
+    @Field(type = FieldType.Text)
+    private String content;  // 게시글 내용
+    @Field(type = FieldType.Text)
+    private String nickname;  // 작성자 이메일 (Member 정보)
+    @Field(type = FieldType.Long)
+    private Long wishCount;  // 위시 수
+    @Field(type = FieldType.Long)
+    private Long viewCount;  // 조회 수
+    @Field(type = FieldType.Keyword)
+    private String category;  // 카테고리
+}

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardElasticsearchRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardElasticsearchRepository.java
@@ -1,0 +1,10 @@
+package com.example.fastboard.domain.board.repository;
+
+import com.example.fastboard.domain.board.entity.BoardDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import java.util.List;
+
+public interface BoardElasticsearchRepository extends ElasticsearchRepository<BoardDocument,Long> {
+    List<BoardDocument> findByTitleContaining(String title);
+}

--- a/src/main/java/com/example/fastboard/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/fastboard/domain/search/controller/SearchController.java
@@ -1,0 +1,37 @@
+package com.example.fastboard.domain.search.controller;
+
+import com.example.fastboard.domain.board.entity.BoardDocument;
+import com.example.fastboard.domain.search.service.SearchService;
+import com.example.fastboard.global.common.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @PostMapping("/migrate")
+    public ResponseEntity<String> migrate() {
+        searchService.migrateDataToElasticsearch();
+        return ResponseEntity.ok("Data migration completed successfully.");
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ResponseDTO<List<BoardDocument>>> searchList(
+            @RequestParam(value = "title", required = false) String title,
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(
+                ResponseDTO.okWithData(searchService.searchByTitle(title,pageable))
+        );
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/fastboard/domain/search/service/SearchService.java
@@ -1,0 +1,52 @@
+package com.example.fastboard.domain.search.service;
+
+import com.example.fastboard.domain.board.dto.BoardMapper;
+import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.repository.BoardElasticsearchRepository;
+import com.example.fastboard.domain.board.repository.BoardRepository;
+import com.example.fastboard.domain.board.entity.BoardDocument;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StopWatch;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SearchService {
+
+    private final BoardRepository boardRepository;
+    private final BoardElasticsearchRepository boardElasticsearchRepository;
+
+
+    public List<BoardDocument> searchByTitle(String title, Pageable pageable){
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+
+
+        List<BoardDocument> byTitle = boardElasticsearchRepository.findByTitleContaining(title);
+
+        stopWatch.stop();
+        log.info("Execution time: " + stopWatch.getTotalTimeMillis() + " ms");
+
+        System.out.println(byTitle.size());
+
+        return null;
+    }
+
+    public void migrateDataToElasticsearch() {
+        List<Board> boards = boardRepository.findAll();
+
+        System.out.println(boards.size());
+        List<BoardDocument> boardDocuments = boards.stream()
+                .map(BoardMapper::toDocument)
+                .collect(Collectors.toList());
+
+
+        boardElasticsearchRepository.saveAll(boardDocuments); // Elasticsearch에 저장
+    }
+}

--- a/src/main/java/com/example/fastboard/global/config/ElasticsearchConfig.java
+++ b/src/main/java/com/example/fastboard/global/config/ElasticsearchConfig.java
@@ -1,0 +1,19 @@
+package com.example.fastboard.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+
+@Configuration
+@EnableElasticsearchRepositories
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+                .connectedTo("localhost:9200")
+                .build();
+    }
+}


### PR DESCRIPTION
### 환경 
- es01, es02 2개의 노드 생성
![image](https://github.com/user-attachments/assets/1b18b41c-fd8b-4fab-9956-2ac478df2c1e)

### 설치 방법
<nori 설치>
```
docker exec -it "container_name" /bin/bash
./bin/elasticsearch-plugin install analysis-nori
```

<인덱스 생성 코드>
```
PUT /boards
{
  "settings": {
    "analysis": {
      "tokenizer": {
        "nori_mixed": {
          "type": "nori_tokenizer",
          "decompound_mode": "mixed"
        }
      },
      "analyzer": {
        "nori": {
          "type": "custom",
          "tokenizer": "nori_mixed",
          "char_filter": [
           "html_strip"  
          ],                
          "filter": [
            "lowercase"
          ]
        }
      }
    },
    "number_of_shards": 2,
    "number_of_replicas": 1
  },
  "mappings": {
    "properties": {
      "id": {
        "type": "keyword"  
      },
      "title": {
        "type": "text",
        "analyzer": "nori" 
      },
      "content": {
        "type": "text",
        "analyzer": "nori"  
      },
      "nickname": {
        "type": "text",
        "analyzer": "nori"
      },
      "wishCount": {
        "type": "long"  
      },
      "viewCount": {
        "type": "long" 
      },
      "category": {
        "type": "keyword"
      }
    }
  }
}
```
- "number_of_shards","number_of_replicas" : 2개의 프라이머리 샤드, 1개의 레플리카 샤드(복제용) 생성
- 형태소 분석기는 `nori_tokenizer` 사용 (한글 지원)
  - decompound_mode: "mixed"로 설정 (ex. “국민은행”은 “국민”과 “은행”으로 분해)
- Character filter 설정을 통해 html태그 제거

### 엘라스틱서치는 문서 저장 과정에서 3종류의 필터를 거침
1. Character Filter : Tokenizer 전에 전처리 과정
2. Tokenizer Filter : 텍스트에 대한 토큰화 작업을 수행
3. Tokne Filter : 토큰을 마지막 전처리 (치환, 통합, 불용어 처리 등)
![image](https://github.com/user-attachments/assets/8a490ddc-f0af-4f2b-8abd-c9df49254d51)


### html 태그 검색 테스트
![image](https://github.com/user-attachments/assets/9821673b-b753-4f7c-b704-074f72616fc1)
![image](https://github.com/user-attachments/assets/f4261ffb-2b9e-48df-8204-ae3d447f5445)
![image](https://github.com/user-attachments/assets/9c34eb90-a6ab-4b65-b448-2740233a80b0)


### 성능 측정
- 데이터 수 : 5천 개
- 검색어 : title : a
- 결과
  - mysql   
![image](https://github.com/user-attachments/assets/5a653996-99f3-4874-a68a-9b21d0511a06)
  - es (dto 변환도 안함...)
![image](https://github.com/user-attachments/assets/20740820-0f09-4c24-b6bb-0807af41a68e)

### 왜 ES가 더 느리지...
1. 데이터 수가 너무 적다
5. es 환경 설정 최적화가 되어있지 않다.

=> 기본적으로 es 검색 플로우는 다음을 따른다.
```
1. 쿼리 파싱
2. 쿼리가 여러 샤드로 분배
6. 모든 노드와 샤드로 쿼리가 전달
7. 샤드 내에서 역 인덱스를 사용해 해당 키워드가 포함된 문서를 찾아냄
8. 점수 계산
9. 코디네이터 노드가 수집하여 결과 병합 후 결과 반환
```
- 몇 천건의 데이터는 최적화가 잘 된 mysql이 더 빠를 수 있다고 하는데, 이를 테스트 하려면 더 많은 샘플 데이터를 만들어야 하나보다..!

