### PR TITLE
[Feature] : DELETE /api/boards/comments/{comment_id} 댓글 삭제

### DIFF
--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -148,7 +148,7 @@ public class BoardController {
     @PostMapping("/{boardId}/comments")
     public ResponseEntity<ApiResponse> postComment(@PathVariable Long boardId, @RequestBody CommentPostReq commentPostReq, Principal principal) {
         Long userId = Long.parseLong(principal.getName());
-        CommentPostParam commentPostParam = new CommentPostParam(boardId, userId, commentPostReq);
+        CommentPostParam commentPostParam = new CommentPostParam(boardId, userId, null ,commentPostReq);
         BoardComment boardComment = commentPostService.saveComment(commentPostParam);
 
         CommentGetRes body = CommentGetRes.builder()
@@ -158,7 +158,26 @@ public class BoardController {
                 .authorId(boardComment.getMember().getId())
                 .build();
 
-        ApiResponse response = new ApiResponse(HttpStatus.CREATED.value(), "게시글이 생성되었습니다", body);
+        ApiResponse response = new ApiResponse(HttpStatus.CREATED.value(), "댓글이 생성되었습니다", body);
+
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @PostMapping("/{boardId}/comments/{commentId}")
+    public ResponseEntity<ApiResponse> postChildComment(@PathVariable Long boardId, @PathVariable Long commentId, @RequestBody CommentPostReq commentPostReq, Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        CommentPostParam commentPostParam = new CommentPostParam(boardId, userId, commentId ,commentPostReq);
+        BoardComment boardComment = commentPostService.saveComment(commentPostParam);
+
+
+        CommentGetRes body = CommentGetRes.builder()
+                .commentId(boardComment.getId())
+                .author(boardComment.getMember().getNickname())
+                .content(boardComment.getContent())
+                .authorId(boardComment.getMember().getId())
+                .build();
+
+        ApiResponse response = new ApiResponse(HttpStatus.CREATED.value(), "대댓글이 생성되었습니다", body);
 
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -2,6 +2,7 @@ package com.example.fastboard.domain.board.controller;
 
 import com.example.fastboard.domain.board.dto.parameter.BoardPostParam;
 import com.example.fastboard.domain.board.dto.parameter.BoardUpdateParam;
+import com.example.fastboard.domain.board.dto.parameter.CommentDeleteParam;
 import com.example.fastboard.domain.board.dto.parameter.CommentPostParam;
 import com.example.fastboard.domain.board.dto.request.BoardPostReq;
 import com.example.fastboard.domain.board.dto.request.CommentPostReq;
@@ -37,6 +38,7 @@ public class BoardController {
     private final BoardDeleteService boardDeleteService;
     private final CommentPostService commentPostService;
     private final CommentGetService commentGetService;
+    private final CommentDeleteService commentDeleteService;
 
     @PostMapping
     public ResponseEntity<ApiResponse> post(@RequestBody BoardPostReq boardPostReq, Principal principal) {
@@ -192,8 +194,6 @@ public class BoardController {
        List<CommentGetRes> commentGetResList = new ArrayList<>();
        Map<Long, CommentGetRes> map = new HashMap<>();
 
-       log.info("size : {}", boardComments.size());
-
        boardComments.stream().forEach(c -> {
            CommentGetRes comment = CommentGetRes.builder()
                    .commentId(c.getId())
@@ -213,5 +213,21 @@ public class BoardController {
 
        ApiResponse body = new ApiResponse(HttpStatus.OK.value(), null, commentGetResList);
        return new ResponseEntity<>(body, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{boardId}/{commentId}")
+    public ResponseEntity<ApiResponse> delete(@PathVariable Long boardId, @PathVariable Long commentId, Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+
+        CommentDeleteParam param = CommentDeleteParam.builder()
+                .commentId(commentId)
+                .boardId(boardId)
+                .userId(userId)
+                .build();
+
+        commentDeleteService.deleteComment(param);
+
+        ApiResponse body = new ApiResponse(HttpStatus.NO_CONTENT.value(), "댓글이 삭제되었습니다.", null);
+        return new ResponseEntity<>(body, HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardController.java
@@ -2,14 +2,19 @@ package com.example.fastboard.domain.board.controller;
 
 import com.example.fastboard.domain.board.dto.parameter.BoardPostParam;
 import com.example.fastboard.domain.board.dto.parameter.BoardUpdateParam;
+import com.example.fastboard.domain.board.dto.parameter.CommentPostParam;
 import com.example.fastboard.domain.board.dto.request.BoardPostReq;
+import com.example.fastboard.domain.board.dto.request.CommentPostReq;
 import com.example.fastboard.domain.board.dto.response.BoardGetRes;
 import com.example.fastboard.domain.board.dto.response.BoardPageRes;
 import com.example.fastboard.domain.board.dto.response.BoardPostRes;
+import com.example.fastboard.domain.board.dto.response.CommentGetRes;
 import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.entity.BoardComment;
 import com.example.fastboard.domain.board.service.BoardDeleteService;
 import com.example.fastboard.domain.board.service.BoardGetService;
 import com.example.fastboard.domain.board.service.BoardPostService;
+import com.example.fastboard.domain.board.service.CommentPostService;
 import com.example.fastboard.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -29,6 +34,7 @@ public class BoardController {
     private final BoardPostService boardPostService;
     private final BoardGetService boardGetService;
     private final BoardDeleteService boardDeleteService;
+    private final CommentPostService commentPostService;
 
     @PostMapping
     public ResponseEntity<ApiResponse> post(@RequestBody BoardPostReq boardPostReq, Principal principal) {
@@ -136,5 +142,24 @@ public class BoardController {
         boardDeleteService.deleteBoard(boardId);
         ApiResponse response = new ApiResponse(HttpStatus.NO_CONTENT.value(), "게시글이 삭제되었습니다.", null);
         return new ResponseEntity<>(response, HttpStatus.NO_CONTENT);
+    }
+
+
+    @PostMapping("/{boardId}/comments")
+    public ResponseEntity<ApiResponse> postComment(@PathVariable Long boardId, @RequestBody CommentPostReq commentPostReq, Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        CommentPostParam commentPostParam = new CommentPostParam(boardId, userId, commentPostReq);
+        BoardComment boardComment = commentPostService.saveComment(commentPostParam);
+
+        CommentGetRes body = CommentGetRes.builder()
+                .commentId(boardComment.getId())
+                .author(boardComment.getMember().getNickname())
+                .content(boardComment.getContent())
+                .authorId(boardComment.getMember().getId())
+                .build();
+
+        ApiResponse response = new ApiResponse(HttpStatus.CREATED.value(), "게시글이 생성되었습니다", body);
+
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/controller/BoardImageController.java
+++ b/src/main/java/com/example/fastboard/domain/board/controller/BoardImageController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.web.bind.annotation.*;
@@ -29,7 +30,7 @@ public class BoardImageController {
     public final BoardImagePostService boardImagePostService;
     public final BoardImageGetService boardImageGetService;
 
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse> createBoardImage(@RequestParam(value = "image") MultipartFile file) {
         BoardImage boardImage = boardImagePostService.upload(file);
 

--- a/src/main/java/com/example/fastboard/domain/board/dto/parameter/CommentDeleteParam.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/parameter/CommentDeleteParam.java
@@ -1,0 +1,10 @@
+package com.example.fastboard.domain.board.dto.parameter;
+
+import lombok.Builder;
+
+@Builder
+public record CommentDeleteParam(
+        Long userId,
+        Long boardId,
+        Long commentId
+) {}

--- a/src/main/java/com/example/fastboard/domain/board/dto/parameter/CommentPostParam.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/parameter/CommentPostParam.java
@@ -8,10 +8,10 @@ public class CommentPostParam {
     public Long parentId;
     public String content;
 
-    public CommentPostParam(Long boardId, Long userId, CommentPostReq commentPostReq) {
+    public CommentPostParam(Long boardId, Long userId, Long parentId ,CommentPostReq commentPostReq) {
         this.boardId = boardId;
         this.userId = userId;
-        this.parentId = commentPostReq.parentCommentId();
+        this.parentId = parentId;
         this.content = commentPostReq.content();
     }
 }

--- a/src/main/java/com/example/fastboard/domain/board/dto/parameter/CommentPostParam.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/parameter/CommentPostParam.java
@@ -1,0 +1,17 @@
+package com.example.fastboard.domain.board.dto.parameter;
+
+import com.example.fastboard.domain.board.dto.request.CommentPostReq;
+
+public class CommentPostParam {
+    public Long boardId;
+    public Long userId;
+    public Long parentId;
+    public String content;
+
+    public CommentPostParam(Long boardId, Long userId, CommentPostReq commentPostReq) {
+        this.boardId = boardId;
+        this.userId = userId;
+        this.parentId = commentPostReq.parentCommentId();
+        this.content = commentPostReq.content();
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/dto/request/CommentPostReq.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/request/CommentPostReq.java
@@ -1,0 +1,9 @@
+package com.example.fastboard.domain.board.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record CommentPostReq (
+        String content,
+        Long parentCommentId
+) {}

--- a/src/main/java/com/example/fastboard/domain/board/dto/request/CommentPostReq.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/request/CommentPostReq.java
@@ -4,6 +4,5 @@ import lombok.Builder;
 
 @Builder
 public record CommentPostReq (
-        String content,
-        Long parentCommentId
+        String content
 ) {}

--- a/src/main/java/com/example/fastboard/domain/board/dto/response/CommentGetRes.java
+++ b/src/main/java/com/example/fastboard/domain/board/dto/response/CommentGetRes.java
@@ -1,0 +1,14 @@
+package com.example.fastboard.domain.board.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CommentGetRes(
+        Long commentId,
+        String content,
+        Long authorId,
+        String author,
+        List<CommentGetRes> childComments
+) {}

--- a/src/main/java/com/example/fastboard/domain/board/entity/BoardComment.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/BoardComment.java
@@ -3,6 +3,8 @@ package com.example.fastboard.domain.board.entity;
 import com.example.fastboard.domain.member.entity.Member;
 import com.example.fastboard.global.common.entity.BaseEntitySoftDelete;
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
@@ -10,6 +12,7 @@ import java.util.List;
 
 @Entity
 @NoArgsConstructor
+@Getter
 public class BoardComment extends BaseEntitySoftDelete {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +27,13 @@ public class BoardComment extends BaseEntitySoftDelete {
     private BoardComment parentComment;     //부모 댓글
     @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BoardComment> childComments = new ArrayList<>();
+
+
+    @Builder
+    public BoardComment(String content, Board parentBoard, Member member, BoardComment parentComment) {
+        this.content = content;
+        this.parentBoard = parentBoard;
+        this.member = member;
+        this.parentComment = parentComment;
+    }
 }

--- a/src/main/java/com/example/fastboard/domain/board/entity/BoardComment.java
+++ b/src/main/java/com/example/fastboard/domain/board/entity/BoardComment.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.List;
 @Entity
 @NoArgsConstructor
 @Getter
+@BatchSize(size = 20)
 public class BoardComment extends BaseEntitySoftDelete {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/fastboard/domain/board/exception/BoardErrorCode.java
+++ b/src/main/java/com/example/fastboard/domain/board/exception/BoardErrorCode.java
@@ -7,7 +7,8 @@ public enum BoardErrorCode implements ErrorCode {
     IMAGE_UPLOAD_FAIL("이미지 업로드에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     IMAGE_NOT_FOUND("이미지를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     MEMBER_NOT_EQUAL("게시글의 작성자가 압니니다.", HttpStatus.BAD_REQUEST),
-    BOARD_NOT_FOUND("해당 게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    BOARD_NOT_FOUND("해당 게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    NOT_FOUND_COMMENT("해당 댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
 
     private final String message;

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardCommentRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardCommentRepository.java
@@ -18,5 +18,7 @@ public interface BoardCommentRepository extends JpaRepository<BoardComment, Long
     @Query("SELECT C FROM BoardComment C JOIN FETCH C.member  WHERE C.parentBoard.id = :boardId  ORDER BY C.parentComment.id NULLS FIRST, C.createdAt ASC")
     Page<BoardComment> findAllByParentBoardId(@Param("boardId") Long boardId, Pageable pageable);
 
+    @Query("SELECT C FROM BoardComment C WHERE C.member.id = :memberId AND C.id = :id AND C.parentBoard.id = :boardId")
+    Optional<BoardComment> findByIdAndParentBoardId(@Param("memberId") Long memberId, @Param("id") Long id, @Param("boardId") Long boardId);
 
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardCommentRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardCommentRepository.java
@@ -1,7 +1,11 @@
 package com.example.fastboard.domain.board.repository;
 
 import com.example.fastboard.domain.board.entity.BoardComment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,4 +14,9 @@ import java.util.Optional;
 public interface BoardCommentRepository extends JpaRepository<BoardComment, Long> {
 
     Optional<BoardComment> findById(Long id);
+
+    @Query("SELECT C FROM BoardComment C JOIN FETCH C.member  WHERE C.parentBoard.id = :boardId  ORDER BY C.parentComment.id NULLS FIRST, C.createdAt ASC")
+    Page<BoardComment> findAllByParentBoardId(@Param("boardId") Long boardId, Pageable pageable);
+
+
 }

--- a/src/main/java/com/example/fastboard/domain/board/repository/BoardCommentRepository.java
+++ b/src/main/java/com/example/fastboard/domain/board/repository/BoardCommentRepository.java
@@ -1,0 +1,13 @@
+package com.example.fastboard.domain.board.repository;
+
+import com.example.fastboard.domain.board.entity.BoardComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BoardCommentRepository extends JpaRepository<BoardComment, Long> {
+
+    Optional<BoardComment> findById(Long id);
+}

--- a/src/main/java/com/example/fastboard/domain/board/service/CommentDeleteService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/CommentDeleteService.java
@@ -1,0 +1,24 @@
+package com.example.fastboard.domain.board.service;
+
+import com.example.fastboard.domain.board.dto.parameter.CommentDeleteParam;
+import com.example.fastboard.domain.board.entity.BoardComment;
+import com.example.fastboard.domain.board.exception.BoardErrorCode;
+import com.example.fastboard.domain.board.exception.BoardException;
+import com.example.fastboard.domain.board.repository.BoardCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentDeleteService {
+    private final BoardCommentRepository boardCommentRepository;
+
+    public void deleteComment(CommentDeleteParam param) {
+        BoardComment comment = boardCommentRepository.findByIdAndParentBoardId(param.userId(),
+                param.commentId(), param.boardId()).orElseThrow(() -> new BoardException(BoardErrorCode.NOT_FOUND_COMMENT));
+
+        boardCommentRepository.delete(comment);
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/service/CommentGetService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/CommentGetService.java
@@ -1,0 +1,23 @@
+package com.example.fastboard.domain.board.service;
+
+import com.example.fastboard.domain.board.entity.BoardComment;
+import com.example.fastboard.domain.board.repository.BoardCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class CommentGetService {
+    private final BoardCommentRepository boardCommentRepository;
+
+    public List<BoardComment> getComments(Long boardId ,int pageNo, String criteria) {
+        Pageable pageable = PageRequest.of(pageNo, 10, Sort.by(Sort.Direction.DESC, criteria));
+        return boardCommentRepository.findAllByParentBoardId(boardId, pageable).getContent();
+    }
+}

--- a/src/main/java/com/example/fastboard/domain/board/service/CommentPostService.java
+++ b/src/main/java/com/example/fastboard/domain/board/service/CommentPostService.java
@@ -1,0 +1,43 @@
+package com.example.fastboard.domain.board.service;
+
+import com.example.fastboard.domain.board.dto.parameter.CommentPostParam;
+import com.example.fastboard.domain.board.entity.Board;
+import com.example.fastboard.domain.board.entity.BoardComment;
+import com.example.fastboard.domain.board.exception.BoardErrorCode;
+import com.example.fastboard.domain.board.exception.BoardException;
+import com.example.fastboard.domain.board.repository.BoardCommentRepository;
+import com.example.fastboard.domain.member.entity.Member;
+import com.example.fastboard.domain.member.service.MemberFindService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentPostService {
+    private final BoardCommentRepository boardCommentRepository;
+    private final BoardGetService boardGetService;
+    private final MemberFindService memberFindService;
+
+    public BoardComment saveComment(CommentPostParam commentPostParam) {
+        // 보드 조회.
+        Board board = boardGetService.getBoard(commentPostParam.boardId);
+
+        // 유저 조회.
+        Member member = memberFindService.findMemberById(commentPostParam.userId);
+
+        // 부모 코멘트 조회.
+        BoardComment parentComment = null;
+        if (commentPostParam.parentId != null)
+            parentComment = boardCommentRepository.findById(commentPostParam.parentId).orElseThrow(() -> new BoardException(BoardErrorCode.NOT_FOUND_COMMENT));
+
+
+        BoardComment comment = BoardComment.builder()
+                .parentComment(parentComment)
+                .member(member)
+                .content(commentPostParam.content)
+                .parentBoard(board)
+                .build();
+
+        return boardCommentRepository.save(comment);
+    }
+}


### PR DESCRIPTION
####  Cascade 와 성능
<img width="1090" alt="image" src="https://github.com/user-attachments/assets/c4524a7b-0dbc-48dd-a90a-49d6927efac7">    

`cascade = CascadeType.ALL` 옵션으로 인해, 부모 댓글이 삭제 시 해당 부모 댓글을 참조하고 있는 자식 댓글이 삭제된다.   
이러한 연쇄 작용으로 인해, `1(부모) -> 2(1을 참조) -> 3(1을 참조) -> 4 (3을 참조)` 총 4번의 삭제 쿼리가 발생하였다. 해당 옵션은 분명 편리성을 제공해주지만, 성능적인 면에서는 직접 관리하는 것이 더욱 도움이 될 것 같다!

#### 고려할 점
* 부모 댓글이 삭제된다고, 해당 계층 아래의 있는 모든 댓글이 삭제되는 것이 이상적인 것일까? 
* 부모 댓글 삭제 , 해당 부모의 직속 댓글들의 부모 키 값을 null 로 변경하는 것이 좋아보이긴 한다. (내 생각 . . .)